### PR TITLE
Add FlowRouter back with new API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.2.0
+- Add `FlowRouter` back, compatible with the new API of nested Nuvigators
+- Increase version constraint of `analyzer`
+
 ## 0.1.1
 - Fix a bug when trying to call onDeepLinkNotfound
 

--- a/example/lib/samples/modules/sample_one/navigation/sample_one_router.dart
+++ b/example/lib/samples/modules/sample_one/navigation/sample_one_router.dart
@@ -12,9 +12,9 @@ const screenOneDeepLink =
 @NuRouter()
 class SampleOneRouter extends BaseRouter {
   @override
-  String get deepLinkPrefix => '/sampleOne/';
+  String get deepLinkPrefix => '/sampleOne';
 
-  @NuRoute(deepLink: 'screenOne/:testId')
+  @NuRoute(deepLink: '/screenOne/:testId')
   ScreenRoute screenOne({@required String testId}) => const ScreenRoute(
         builder: ScreenOne.builder,
       );

--- a/example/lib/samples/modules/sample_one/navigation/sample_one_router.g.dart
+++ b/example/lib/samples/modules/sample_one/navigation/sample_one_router.g.dart
@@ -126,7 +126,7 @@ class SampleOneNavigation {
 Map<RouteDef, ScreenRouteBuilder> _$sampleOneScreensMap(
     SampleOneRouter router) {
   return {
-    RouteDef(SampleOneRoutes.screenOne, deepLink: 'screenOne/:testId'):
+    RouteDef(SampleOneRoutes.screenOne, deepLink: '/screenOne/:testId'):
         (RouteSettings settings) {
       final Map<String, Object> args = settings.arguments;
       return router.screenOne(testId: args['testId']);

--- a/example/lib/samples/modules/sample_two/navigation/sample_two_router.dart
+++ b/example/lib/samples/modules/sample_two/navigation/sample_two_router.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:nuvigator/nuvigator.dart';
 import 'package:provider/provider.dart';
 
-import '../bloc/sample_flow_bloc.dart';
 import '../bloc/sample_two_bloc.dart';
 import '../screen/screen_one.dart';
 import '../screen/screen_two.dart';
@@ -19,16 +18,9 @@ class SampleTwoRouter extends BaseRouter {
         );
       };
 
-//  static void screenOneS2Args(String testId) {}
   @NuRoute()
   ScreenRoute<String> screenOne({String testId}) => const ScreenRoute(
         builder: ScreenOne.builder,
-//        wrapper: (screenContext, child) {
-//          return Provider<ScreenOneBloc>.value(
-//            value: ScreenOneBloc(),
-//            child: child,
-//          );
-//        },
       );
 
   @NuRoute(pushMethods: [PushMethodType.push, PushMethodType.pushReplacement])
@@ -39,13 +31,3 @@ class SampleTwoRouter extends BaseRouter {
   Map<RouteDef, ScreenRouteBuilder> get screensMap =>
       _$sampleTwoScreensMap(this);
 }
-
-final sampleTwoNuvigator = Nuvigator<SampleTwoRouter>(
-  router: SampleTwoRouter(),
-  initialRoute: SampleTwoRoutes.screenOne,
-  screenType: cupertinoScreenType,
-  wrapper: (BuildContext context, Widget child) => Provider<SampleFlowBloc>(
-    builder: (_) => SampleFlowBloc(),
-    child: child,
-  ),
-);

--- a/example/lib/samples/navigation/samples_router.dart
+++ b/example/lib/samples/navigation/samples_router.dart
@@ -1,3 +1,4 @@
+import 'package:example/samples/modules/sample_two/bloc/sample_flow_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:nuvigator/nuvigator.dart';
 import 'package:provider/provider.dart';
@@ -29,11 +30,22 @@ class SamplesRouter extends BaseRouter {
 
   @NuRoute()
   FlowRoute<SampleTwoRouter, void> second({String testId}) => FlowRoute(
-        nuvigator: sampleTwoNuvigator,
+        nuvigator: Nuvigator(
+          router: SampleTwoRouter(),
+          initialRoute: SampleTwoRoutes.screenOne,
+          screenType: cupertinoScreenType,
+          wrapper: (BuildContext context, Widget child) => Provider(
+            builder: (_) => SampleFlowBloc(),
+            child: child,
+          ),
+        ),
       );
 
   @NuRouter()
-  final sampleOneRouter = SampleOneRouter();
+  final sampleOneRouter = FlowRouter(
+    SampleOneRouter(),
+    screensType: materialScreenType,
+  );
 
   @override
   Map<RouteDef, ScreenRouteBuilder> get screensMap => _$samplesScreensMap(this);

--- a/lib/builder/helpers.dart
+++ b/lib/builder/helpers.dart
@@ -7,10 +7,6 @@ List<DartType> getGenericTypes(DartType type) {
   return type is ParameterizedType ? type.typeArguments : null;
 }
 
-List<TypeParameterElement> getGenericParameters(DartType type) {
-  return type is ParameterizedType ? type.typeParameters : null;
-}
-
 const nuRouteChecker = TypeChecker.fromRuntime(NuRoute);
 const nuRouterChecker = TypeChecker.fromRuntime(NuRouter);
 

--- a/lib/src/global_router.dart
+++ b/lib/src/global_router.dart
@@ -103,8 +103,7 @@ class GlobalRouter implements Router {
       isInitialRoute: false,
       arguments: arguments,
     );
-    final screenRoute = routeEntry
-        .value(routeSettings)
+    final screenRoute = getScreen(routeSettings)
         .fallbackScreenType(nuvigator.widget.screenType);
     final route = screenRoute.toRoute(routeSettings);
     route.popped.then<dynamic>((dynamic _) async {

--- a/lib/src/router.dart
+++ b/lib/src/router.dart
@@ -113,3 +113,41 @@ abstract class BaseRouter implements Router {
     return getScreen(settings).toRoute(settings);
   }
 }
+
+class FlowRouter<T extends Router, R extends Object> extends BaseRouter {
+  FlowRouter(
+    this.baseRouter, {
+    this.screensType,
+    this.initialScreenType,
+    this.wrapper,
+  });
+
+  final ScreenType initialScreenType;
+  final ScreenType screensType;
+  final Router baseRouter;
+  final WrapperFn wrapper;
+
+  @override
+  ScreenRoute getScreen(RouteSettings settings) {
+    final firstScreen = baseRouter.getScreen(settings);
+    if (firstScreen == null) return null;
+    return FlowRoute<T, R>(
+      screenType: initialScreenType,
+      nuvigator: Nuvigator<T>(
+        router: baseRouter,
+        initialRoute: settings.name,
+        screenType: screensType,
+        wrapper: wrapper,
+        initialArguments: settings.arguments,
+      ),
+    );
+  }
+
+  @override
+  Future<RouteEntry> getRouteEntryForDeepLink(String deepLink) async {
+    return await baseRouter.getRouteEntryForDeepLink(deepLink);
+  }
+
+  @override
+  Map<RouteDef, ScreenRouteBuilder> get screensMap => null;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   build_config: '>=0.2.6 <0.5.0'
   code_builder: ^3.2.0
   source_gen: ^0.9.4+5
-  analyzer: '>=0.37.1 <0.39.0'
+  analyzer: '>=0.37.0 <0.39.0'
   dart_style: ^1.3.3
   flutter:
     sdk: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nuvigator
 description: A powerful and strongly typed routing abstraction over Flutter navigator, providing some new features and an easy way to define routers with code generation.
-version: 0.1.1
+version: 0.2.0
 
 homepage: https://github.com/nubank/nuvigator
 


### PR DESCRIPTION
This PR adds back the old abstraction of the FlowRouter, but now compatible with the new API.
Just wrap another router into the `FlowRouter` class and pass any additional parameters to create a flow creator Router.

`FlowRouters` act as normal routers when grouped into other routers, however when they match some route they will present the screen into a nested `Nuvigator` controlled by the `baseRouter`.
This allows having nested deepLink or/and routes that created nested Nuvigators dynamically. Also it's useful when some flow has not a defined starting screen and instead can be started from several of its screens, using `FlowRouter` allow this kind of behavior.