### PR TITLE
Fix the bug on didPushRoute and didPopRoute (Android only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.2.1
+- Fix the bug when Android back button is pressed closing the app. Now, 
+  when the back button is pressed, the nuvigator will try to close the 
+  current page and will just close the app when doesn't have any pages to pop. 
+
 ## 0.2.0
 - Add `FlowRouter` back, compatible with the new API of nested Nuvigators
 - Increase version constraint of `analyzer`

--- a/example/lib/samples/navigation/samples_router.dart
+++ b/example/lib/samples/navigation/samples_router.dart
@@ -35,7 +35,7 @@ class SamplesRouter extends BaseRouter {
           initialRoute: SampleTwoRoutes.screenOne,
           screenType: cupertinoScreenType,
           wrapper: (BuildContext context, Widget child) => Provider(
-            builder: (_) => SampleFlowBloc(),
+            create: (_) => SampleFlowBloc(),
             child: child,
           ),
         ),

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  provider: ^3.0.0+1
+  provider: ^3.2.0
   nuvigator:
     path: ../
 

--- a/lib/src/nuvigator.dart
+++ b/lib/src/nuvigator.dart
@@ -95,7 +95,8 @@ class Nuvigator<T extends Router> extends Navigator {
   }
 }
 
-class NuvigatorState<T extends Router> extends NavigatorState with WidgetsBindingObserver {
+class NuvigatorState<T extends Router> extends NavigatorState
+    with WidgetsBindingObserver {
   NuvigatorState<GlobalRouter> get _rootNuvigator =>
       Nuvigator.of<GlobalRouter>(context, rootNuvigator: true) ?? this;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nuvigator
 description: A powerful and strongly typed routing abstraction over Flutter navigator, providing some new features and an easy way to define routers with code generation.
-version: 0.2.0
+version: 0.2.1
 
 homepage: https://github.com/nubank/nuvigator
 


### PR DESCRIPTION
Fix the bug when Android back button is pressed closing the app. Now, when the back button is pressed, the nuvigator will try to close the current page and will just close the app when doesn't have any pages to pop. 