### PR TITLE
Allow deepLinks as the initialRoute

### DIFF
--- a/example/lib/samples/modules/sample_one/navigation/sample_one_router.dart
+++ b/example/lib/samples/modules/sample_one/navigation/sample_one_router.dart
@@ -13,7 +13,7 @@ const screenOneDeepLink =
 @NuRouter()
 class SampleOneRouter extends Router {
   @override
-  Future<String> get deepLinkPrefix async => '/sampleOne';
+  String get deepLinkPrefix => '/sampleOne';
 
   @NuRoute(deepLink: '/screenOne/:testId')
   ScreenRoute<String> screenOne({@required String testId}) => ScreenRoute(

--- a/example/lib/samples/navigation/samples_router.dart
+++ b/example/lib/samples/navigation/samples_router.dart
@@ -13,7 +13,7 @@ part 'samples_router.g.dart';
 @NuRouter()
 class SamplesRouter extends Router {
   @override
-  Future<String> get deepLinkPrefix async => 'deepprefix';
+  String get deepLinkPrefix => 'deepprefix';
 
   @NuRoute()
   ScreenRoute<void> home() => ScreenRoute(

--- a/lib/src/nuvigator.dart
+++ b/lib/src/nuvigator.dart
@@ -54,7 +54,8 @@ class NuvigatorStateTracker extends NavigatorObserver {
 class Nuvigator<T extends Router> extends Navigator {
   Nuvigator({
     @required this.router,
-    @required String initialRoute,
+    String initialRoute,
+    String initialDeepLink,
     Key key,
     List<NavigatorObserver> observers = const [],
     this.screenType = materialScreenType,
@@ -62,7 +63,7 @@ class Nuvigator<T extends Router> extends Navigator {
     this.debug = false,
     this.inheritableObservers = const [],
   })  : assert(router != null),
-        assert(initialRoute != null),
+        assert(initialRoute != null || initialDeepLink != null),
         super(
           observers: [
             HeroController(),
@@ -73,7 +74,8 @@ class Nuvigator<T extends Router> extends Navigator {
               ?.fallbackScreenType(screenType)
               ?.toRoute(settings),
           key: key,
-          initialRoute: router.getInitialRoute(initialRoute),
+          initialRoute:
+              initialRoute ?? router.getScreenNameFromDeepLink(initialDeepLink),
         );
 
   Nuvigator<T> copyWith({

--- a/lib/src/nuvigator.dart
+++ b/lib/src/nuvigator.dart
@@ -73,7 +73,7 @@ class Nuvigator<T extends Router> extends Navigator {
               ?.fallbackScreenType(screenType)
               ?.toRoute(settings),
           key: key,
-          initialRoute: initialRoute,
+          initialRoute: router.getInitialRoute(initialRoute),
         );
 
   Nuvigator<T> copyWith({

--- a/lib/src/router.dart
+++ b/lib/src/router.dart
@@ -64,7 +64,7 @@ abstract class Router {
 
   Map<RouteDef, ScreenRouteBuilder> get screensMap => {};
 
-  Future<String> get deepLinkPrefix async => '';
+  String get deepLinkPrefix => '';
 
   /// Get the specified router that can be grouped in this router
   T getRouter<T extends Router>() {
@@ -88,16 +88,15 @@ abstract class Router {
     return null;
   }
 
-  Future<RouteEntry> getRouteEntryForDeepLink(String deepLink) async {
-    final thisDeepLinkPrefix = await deepLinkPrefix;
+  RouteEntry getRouteEntryForDeepLink(String deepLink) {
+    final thisDeepLinkPrefix = deepLinkPrefix;
     final prefixRegex = RegExp('^$thisDeepLinkPrefix.*');
     if (prefixRegex.hasMatch(deepLink)) {
-      final screen = await _getRouteEntryForDeepLink(deepLink);
+      final screen = _getRouteEntryForDeepLink(deepLink);
       if (screen != null) return screen;
       for (final Router router in routers) {
         final newDeepLink = deepLink.replaceFirst(thisDeepLinkPrefix, '');
-        final subRouterEntry =
-            await router.getRouteEntryForDeepLink(newDeepLink);
+        final subRouterEntry = router.getRouteEntryForDeepLink(newDeepLink);
         if (subRouterEntry != null) {
           final fullTemplate =
               thisDeepLinkPrefix + (subRouterEntry.key.deepLink ?? '');
@@ -111,14 +110,22 @@ abstract class Router {
     return null;
   }
 
-  Future<bool> canOpenDeepLink(Uri url) async {
-    return (await getRouteEntryForDeepLink(deepLinkString(url))) != null;
+  String getInitialRoute(String deepLinkOrRouteName) {
+    final maybeDeepLinkRoute = getRouteEntryForDeepLink(deepLinkOrRouteName);
+
+    return maybeDeepLinkRoute != null
+        ? maybeDeepLinkRoute.key.routeName
+        : deepLinkOrRouteName;
+  }
+
+  bool canOpenDeepLink(Uri url) {
+    return getRouteEntryForDeepLink(deepLinkString(url)) != null;
   }
 
   Future<T> openDeepLink<T>(Uri url,
       [dynamic arguments, bool isFromNative = false]) async {
     if (this == nuvigator.rootRouter) {
-      final routeEntry = await getRouteEntryForDeepLink(deepLinkString(url));
+      final routeEntry = getRouteEntryForDeepLink(deepLinkString(url));
 
       if (routeEntry == null) {
         if (onDeepLinkNotFound != null)
@@ -148,13 +155,13 @@ abstract class Router {
     return screenBuilder(settings).wrapWith(screensWrapper);
   }
 
-  Future<RouteEntry> _getRouteEntryForDeepLink(String deepLink) async {
+  RouteEntry _getRouteEntryForDeepLink(String deepLink) {
     for (var screenEntry in screensMap.entries) {
       final routeDef = screenEntry.key;
       final screenBuilder = screenEntry.value;
       final currentDeepLink = routeDef.deepLink;
       if (currentDeepLink == null) continue;
-      final fullTemplate = await deepLinkPrefix + currentDeepLink;
+      final fullTemplate = deepLinkPrefix + currentDeepLink;
       final regExp = pathToRegExp(fullTemplate);
       if (regExp.hasMatch(deepLink)) {
         return RouteEntry(

--- a/lib/src/router.dart
+++ b/lib/src/router.dart
@@ -110,12 +110,8 @@ abstract class Router {
     return null;
   }
 
-  String getInitialRoute(String deepLinkOrRouteName) {
-    final maybeDeepLinkRoute = getRouteEntryForDeepLink(deepLinkOrRouteName);
-
-    return maybeDeepLinkRoute != null
-        ? maybeDeepLinkRoute.key.routeName
-        : deepLinkOrRouteName;
+  String getScreenNameFromDeepLink(String initialDeepLink) {
+    return getRouteEntryForDeepLink(initialDeepLink)?.key?.routeName;
   }
 
   bool canOpenDeepLink(Uri url) {

--- a/test/helpers.dart
+++ b/test/helpers.dart
@@ -21,7 +21,7 @@ class TestRouter extends Router {
 
 class TestRouterWPrefix extends Router {
   @override
-  Future<String> get deepLinkPrefix async => 'prefix/';
+  String get deepLinkPrefix => 'prefix/';
 
   @override
   Map<RouteDef, ScreenRouteBuilder> get screensMap => {
@@ -41,7 +41,7 @@ class TestRouterWPrefix extends Router {
 
 class GroupTestRouter extends Router {
   @override
-  Future<String> get deepLinkPrefix async => 'group/';
+  String get deepLinkPrefix => 'group/';
 
   TestRouter testRouter = TestRouter();
 

--- a/test/router_test.dart
+++ b/test/router_test.dart
@@ -81,25 +81,16 @@ void main() {
     expect(mainRouter.getRouter<TestRouterWPrefix>(), null);
   });
 
-  group('initial route', () {
-    test('when its a known deep link without prefix', () async {
+  group('screen name from deep link', () {
+    test('when its a known deep link', () async {
       final testRouter = TestRouter();
-      expect(testRouter.getInitialRoute('test/simple'), 'firstScreen');
+      expect(
+          testRouter.getScreenNameFromDeepLink('test/simple'), 'firstScreen');
     });
 
-    test('when its a know deep link with prefix', () async {
-      final testRouterWPrefix = TestRouterWPrefix();
-      expect(testRouterWPrefix.getInitialRoute('prefix/test/simple'),
-          'firstScreen');
-    });
-
-    test('when its a route name', () {
+    test('when its an unknown deep link returns null', () async {
       final testRouter = TestRouter();
-      expect(testRouter.getInitialRoute('firstScreen'), 'firstScreen');
-    });
-    test('when its a route name from a prefixed router', () async {
-      final testRouterWPrefix = TestRouterWPrefix();
-      expect(testRouterWPrefix.getInitialRoute('firstScreen'), 'firstScreen');
+      expect(testRouter.getScreenNameFromDeepLink('this/doesnt/exist'), null);
     });
   });
 }

--- a/test/router_test.dart
+++ b/test/router_test.dart
@@ -27,21 +27,19 @@ void main() {
 
   test('router retrieves the right screen for the deepLink', () async {
     final testRouter = TestRouter();
-    final routeEntry = await testRouter.getRouteEntryForDeepLink('test/simple');
+    final routeEntry = testRouter.getRouteEntryForDeepLink('test/simple');
     expect(routeEntry.value(const RouteSettings()).debugKey,
         'testRouterFirstScreen');
   });
 
   test('router can open deepLink', () async {
     final testRouter = TestRouter();
-    expect(await testRouter.canOpenDeepLink(Uri.parse('test/simple')), true);
-    expect(await testRouter.canOpenDeepLink(Uri.parse('test/simple/another')),
-        false);
-    expect(await testRouter.canOpenDeepLink(Uri.parse('test/')), false);
-    expect(
-        await testRouter.canOpenDeepLink(Uri.parse('test/123/params')), true);
-    expect(await testRouter.canOpenDeepLink(Uri.parse('test/params')), false);
-    expect(await testRouter.canOpenDeepLink(Uri.parse('test//params')), false);
+    expect(testRouter.canOpenDeepLink(Uri.parse('test/simple')), true);
+    expect(testRouter.canOpenDeepLink(Uri.parse('test/simple/another')), false);
+    expect(testRouter.canOpenDeepLink(Uri.parse('test/')), false);
+    expect(testRouter.canOpenDeepLink(Uri.parse('test/123/params')), true);
+    expect(testRouter.canOpenDeepLink(Uri.parse('test/params')), false);
+    expect(testRouter.canOpenDeepLink(Uri.parse('test//params')), false);
   });
 
   test('router on deepLinkNotFound', () async {
@@ -57,7 +55,7 @@ void main() {
     expect(mockNuvigator.routePushed, null);
   });
 
-  test('router open deepLink correcntly', () async {
+  test('router open deepLink correctly', () async {
     final testRouter = TestRouter();
     final mockNuvigator = MockNuvigator(testRouter);
     testRouter.nuvigator = mockNuvigator;
@@ -81,5 +79,27 @@ void main() {
     expect(mainRouter.getRouter<TestRouter>(), mainRouter.testRouter);
     expect(mainRouter.getRouter<GroupTestRouter>(), mainRouter);
     expect(mainRouter.getRouter<TestRouterWPrefix>(), null);
+  });
+
+  group('initial route', () {
+    test('when its a known deep link without prefix', () async {
+      final testRouter = TestRouter();
+      expect(testRouter.getInitialRoute('test/simple'), 'firstScreen');
+    });
+
+    test('when its a know deep link with prefix', () async {
+      final testRouterWPrefix = TestRouterWPrefix();
+      expect(testRouterWPrefix.getInitialRoute('prefix/test/simple'),
+          'firstScreen');
+    });
+
+    test('when its a route name', () {
+      final testRouter = TestRouter();
+      expect(testRouter.getInitialRoute('firstScreen'), 'firstScreen');
+    });
+    test('when its a route name from a prefixed router', () async {
+      final testRouterWPrefix = TestRouterWPrefix();
+      expect(testRouterWPrefix.getInitialRoute('firstScreen'), 'firstScreen');
+    });
   });
 }


### PR DESCRIPTION
In some scenarios we'd want to use deep links as the initial route - let's say we're opening a flutter screen from a native screen and want to directly enter a screen, the canonical way to do this with flutter is to set the initialRoute property on the native side and so Material's Navigation will know that it needs to open some other path as route. The problem is that in this scenario we shouldn't expect the native screen to know the name of nuvigator's route and thus, using a deep link seems like a more abstract way to do this.
This commit adds support to set a deep link as the initialRoute value however, to do this we needed to change the deeplink resolution function (getRouteEntryForDeepLink) to be synchronous instead of asynchronous. The reason it was async before was that the function to get the deepLink prefix (deepLinkPrefix) was async as a hook for a case in which someone needed to set this asynchronously. However, we feel that while it's a breaking change, it's more valueable to support deep links as the initial route than the capability of getting the prefix asynchronously.