### PR TITLE
Perform a SystemNavigator.pop() when trying to pop the root screen

### DIFF
--- a/lib/src/nuvigator.dart
+++ b/lib/src/nuvigator.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:nuvigator/nuvigator.dart';
 
 import 'router.dart';
@@ -274,6 +275,9 @@ class NuvigatorState<T extends Router> extends NavigatorState
     var isPopped = false;
     if (canPop()) {
       isPopped = super.pop<T>(result);
+    } else if (this == rootNuvigator) {
+      isPopped = true;
+      SystemNavigator.pop();
     }
     if (!isPopped && this != rootNuvigator && parent != null) {
       return parentPop<T>(result);

--- a/lib/src/nuvigator.dart
+++ b/lib/src/nuvigator.dart
@@ -62,6 +62,7 @@ class Nuvigator<T extends Router> extends Navigator {
     this.wrapper,
     this.debug = false,
     this.inheritableObservers = const [],
+    this.shouldPopRoot = false,
   })  : assert(router != null),
         assert(initialRoute != null),
         super(
@@ -99,6 +100,7 @@ class Nuvigator<T extends Router> extends Navigator {
 
   final T router;
   final bool debug;
+  final bool shouldPopRoot;
   final ScreenType screenType;
   final WrapperFn wrapper;
   final List<ObserverBuilder> inheritableObservers;
@@ -275,7 +277,7 @@ class NuvigatorState<T extends Router> extends NavigatorState
     var isPopped = false;
     if (canPop()) {
       isPopped = super.pop<T>(result);
-    } else if (this == rootNuvigator) {
+    } else if (widget.shouldPopRoot && this == rootNuvigator) {
       isPopped = true;
       SystemNavigator.pop();
     }


### PR DESCRIPTION
Sometimes we may have as a root screen on Flutter a screen that is "closeable" - eg. when we launch a Flutter flow from a Native screen, the root screen on Flutter will usually be something the has a close or back to return back to the previous screen as the behaviour is much more of a "push" than a "replace". In these scenarios, trying to call a Nuvigator.pop() on this screen will fail as it's not poppable. At the same time, even when launching a full Flutter app, the root screen is something that might have a close button or behaviour and the pop() will also not work. But this is a behaviour that should by default happen as pressing the physical back button will pop this activity anyway.
So, this commit implements this behavior on the pop() method: if trying to call pop() on the rootNavigator when the stack is empty it'll perform a SystemNavigator.pop() and kill the screen.