### PR TITLE
Downgrade Analyzer dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   build_config: '>=0.2.6 <0.5.0'
   code_builder: ^3.2.0
   source_gen: '>=0.9.4+4 <0.9.5'
-  analyzer: '>=0.39.4 <0.40.0'
+  analyzer: '>=0.38.5 <0.40.0'
   dart_style: '>=1.2.9 <1.3.4'
   flutter:
     sdk: flutter


### PR DESCRIPTION
Previously we were depending on "analyzer" 0.39.4+, however this was a version greater than the one Flutter's stable is using. This causes this library to not work on Flutter's Stable branch which is undesirable (and at this point unnecessary). As there was no real reason for this enforcing, I'm downgrading to match the version on Flutter stable.