### PR TITLE
Fix of(context) to start the search at the last state instead of root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 0.4.2
+- Fix the `Nuvigator.of(context)` to start the search at the last state instead of root
+
 ## 0.4.1
 - Make `initialDeepLink` work passing arguments to destination route
 

--- a/lib/src/nuvigator.dart
+++ b/lib/src/nuvigator.dart
@@ -138,7 +138,7 @@ class Nuvigator<T extends Router> extends Navigator {
 
   static NuvigatorState ofRouter<T extends Router>(BuildContext context) {
     final NuvigatorState closestNuvigator =
-        context.findRootAncestorStateOfType<NuvigatorState>();
+        context.findAncestorStateOfType<NuvigatorState>();
     return _tryToFindNuvigatorForRouter<T>(closestNuvigator);
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nuvigator
 description: A powerful and strongly typed routing abstraction over Flutter navigator, providing some new features and an easy way to define routers with code generation.
-version: 0.4.1
+version: 0.4.2
 
 homepage: https://github.com/nubank/nuvigator
 


### PR DESCRIPTION
These PR fixes a problem in the Nuvigator.of(context) when trying to get the nuvigator out of the root router.