### PR TITLE
Add support for deepLink parameters with dashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 0.4.6
+- Support query parameters with dashes by converting them to camelCase
+
 ## 0.4.5
 - Downgrade the analyzer dependency to '>=0.38.5 <0.40.0'
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -25,6 +25,7 @@ analyzer:
     # treat missing required parameters as a warning (not a hint)
     missing_required_param: warning
     # treat missing returns as a warning (not a hint)
+    deprecated_member_use: ignore
     missing_return: warning
     # allow having TODOs in the code
     todo: ignore

--- a/lib/src/router.dart
+++ b/lib/src/router.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:path_to_regexp/path_to_regexp.dart';
+import 'package:recase/recase.dart';
 
 import '../nuvigator.dart';
 import 'screen_route.dart';
@@ -17,7 +18,11 @@ Map<String, String> extractDeepLinkParameters(
   final parameters = <String>[];
   final regExp = pathToRegExp(deepLinkTemplate, parameters: parameters);
   final match = regExp.matchAsPrefix(deepLinkString(url));
-  return extract(parameters, match)..addAll(url.queryParameters);
+  final parametersMap = extract(parameters, match)..addAll(url.queryParameters);
+  final camelCasedParametersMap = parametersMap.map((k, v) {
+    return MapEntry(ReCase(k).camelCase, v);
+  });
+  return {...parametersMap, ...camelCasedParametersMap};
 }
 
 class RouteEntry {
@@ -100,8 +105,8 @@ abstract class Router {
     final thisDeepLinkPrefix = deepLinkPrefix;
     final prefixRegex = RegExp('^$thisDeepLinkPrefix.*');
     if (prefixRegex.hasMatch(deepLink)) {
-      final screen = _getRouteEntryForDeepLink(deepLink);
-      if (screen != null) return screen;
+      final routeEntry = _getRouteEntryForDeepLink(deepLink);
+      if (routeEntry != null) return routeEntry;
       for (final Router router in routers) {
         final newDeepLink = deepLink.replaceFirst(thisDeepLinkPrefix, '');
         final subRouterEntry = router.getRouteEntryForDeepLink(newDeepLink);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nuvigator
 description: A powerful and strongly typed routing abstraction over Flutter navigator, providing some new features and an easy way to define routers with code generation.
-version: 0.4.5
+version: 0.4.6
 
 homepage: https://github.com/nubank/nuvigator
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,9 +12,9 @@ dependencies:
   recase: ^3.0.0
   build_config: '>=0.2.6 <0.5.0'
   code_builder: ^3.2.0
-  source_gen: '>=0.9.4+4 <0.9.5'
+  source_gen: '>=0.9.4+4 <0.10.0'
   analyzer: '>=0.38.5 <0.40.0'
-  dart_style: '>=1.2.9 <1.3.4'
+  dart_style: '>=1.2.9 <1.4.0'
   flutter:
     sdk: flutter
   path_to_regexp: ^0.3.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 
 dependencies:
   build: '>=0.12.6 <2.0.0'
+  recase: ^3.0.0
   build_config: '>=0.2.6 <0.5.0'
   code_builder: ^3.2.0
   source_gen: '>=0.9.4+4 <0.9.5'

--- a/test/router_test.dart
+++ b/test/router_test.dart
@@ -100,9 +100,8 @@ void main() {
     test('it can correctly adapt non camelCase keys', () {
       final result = extractDeepLinkParameters(
           Uri.parse('my-route/something?another-one=hello'),
-          'my-route/:my-argument');
+          'my-route/:myArgument');
       expect(result, {
-        'my-argument': 'something',
         'myArgument': 'something',
         'another-one': 'hello',
         'anotherOne': 'hello'

--- a/test/router_test.dart
+++ b/test/router_test.dart
@@ -95,4 +95,18 @@ void main() {
           null);
     });
   });
+
+  group('extracting parameters from deepLink', () {
+    test('it can correctly adapt non camelCase keys', () {
+      final result = extractDeepLinkParameters(
+          Uri.parse('my-route/something?another-one=hello'),
+          'my-route/:my-argument');
+      expect(result, {
+        'my-argument': 'something',
+        'myArgument': 'something',
+        'another-one': 'hello',
+        'anotherOne': 'hello'
+      });
+    });
+  });
 }


### PR DESCRIPTION
To be able to have access to parameters containing dashes in the deepLink, those are going to be converted to camelCase.

Depends on: https://github.com/leonsenft/path_to_regexp