### PR TITLE
Add support for typed screen arguments on deep links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,7 +66,8 @@ example/ios/Flutter/Flutter.podspec
 **/ios/Flutter/flutter_assets/
 **/ios/ServiceDefinitions.json
 **/ios/Runner/GeneratedPluginRegistrant.*
-example/ios/Flutter/flutter_export_environment.sh
+**/ios/Flutter/flutter_export_environment.sh
+**/ios/Flutter/.last_build_id
 
 # Exceptions to above rules.
 !**/ios/**/default.mode1v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 0.6.0
+- Add support for typed screen arguments on deep links. In addition to `String`, we now support `int`, `double,` `bool`, and `DateTime`.
+
 ## 0.5.1
 - Update ReCase version support to '>= 2.0.0 <3.1.0'
 

--- a/build.yaml
+++ b/build.yaml
@@ -6,3 +6,10 @@ builders:
     auto_apply: dependents
     build_to: cache
     applies_builders: ["source_gen|combining_builder"]
+targets:
+  $default:
+    builders:
+      nuvigator:
+        generate_for:
+          - example/**
+          - test/**

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -34,15 +34,12 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Nubank',
       builder: Nuvigator(
-//        debug: true,
         screenType: cupertinoDialogScreenType,
         inheritableObservers: [
           () => TestObserver(),
         ],
         router: SamplesRouter(),
         initialRoute: SamplesRoutes.home,
-//        initialDeepLink: Uri.parse(
-//            'exapp://deepPrefix/sampleOne/screenOne/id_1234_deepLink'),
       ),
     );
   }
@@ -68,7 +65,7 @@ class HomeScreen extends StatelessWidget {
               child: const Text('Go to sample one with flutter navigation'),
               onPressed: () async {
                 final result = await router.sampleOneRouter
-                    .toScreenOne(testId: 'From Home');
+                    .toScreenOne(testId: 'From Home', magicNumber: 0);
                 print('ScreenOneResult: $result');
               }),
           FlatButton(

--- a/example/lib/samples/modules/sample_one/navigation/sample_one_router.dart
+++ b/example/lib/samples/modules/sample_one/navigation/sample_one_router.dart
@@ -8,7 +8,7 @@ import '../screen/screen_two.dart';
 part 'sample_one_router.g.dart';
 
 const screenOneDeepLink =
-    'exapp://deepPrefix/sampleOne/screenOne/id_1234_deepLink';
+    'exapp://deepprefix/sampleOne/screenOne/id_1234_deepLink?magicNumber=42';
 
 @NuRouter()
 class SampleOneRouter extends Router {
@@ -16,12 +16,14 @@ class SampleOneRouter extends Router {
   String get deepLinkPrefix => '/sampleOne';
 
   @NuRoute(deepLink: '/screenOne/:testId')
-  ScreenRoute<String> screenOne({@required String testId}) => ScreenRoute(
+  ScreenRoute<String> screenOne({@required String testId, int magicNumber}) =>
+      ScreenRoute(
         builder: (context) => ScreenOne(
           toBack: () => nuvigator.pop('ResultFromScreenOne'),
           toScreenTwo: toScreenTwo,
           toSampleTwo: () => Router.of<SamplesRouter>(context)
               .toSecond(testId: 'From SampleOne'),
+          magicNumber: magicNumber,
         ),
       );
 

--- a/example/lib/samples/modules/sample_one/navigation/sample_one_router.g.dart
+++ b/example/lib/samples/modules/sample_one/navigation/sample_one_router.g.dart
@@ -13,18 +13,27 @@ class SampleOneRoutes {
 }
 
 class ScreenOneArgs {
-  ScreenOneArgs({@required this.testId});
+  ScreenOneArgs({@required this.testId, @required this.magicNumber});
 
   final String testId;
 
+  final int magicNumber;
+
   static ScreenOneArgs parse(Map<String, Object> args) {
+    if (args == null) {
+      return ScreenOneArgs(testId: null, magicNumber: null);
+    }
     return ScreenOneArgs(
       testId: args['testId'],
+      magicNumber: args['magicNumber'] is String
+          ? int.tryParse(args['magicNumber'])
+          : args['magicNumber'],
     );
   }
 
   Map<String, Object> get toMap => {
         'testId': testId,
+        'magicNumber': magicNumber,
       };
   static ScreenOneArgs of(BuildContext context) {
     final routeSettings = ModalRoute.of(context)?.settings;
@@ -43,43 +52,49 @@ class ScreenOneArgs {
 }
 
 extension SampleOneRouterNavigation on SampleOneRouter {
-  Future<String> toScreenOne({@required String testId}) {
+  Future<String> toScreenOne({@required String testId, int magicNumber}) {
     return nuvigator.pushNamed<String>(
       SampleOneRoutes.screenOne,
       arguments: {
         'testId': testId,
+        'magicNumber': magicNumber,
       },
     );
   }
 
   Future<String> pushReplacementToScreenOne<TO extends Object>(
-      {@required String testId, TO result}) {
+      {@required String testId, int magicNumber, TO result}) {
     return nuvigator.pushReplacementNamed<String, TO>(
       SampleOneRoutes.screenOne,
       arguments: {
         'testId': testId,
+        'magicNumber': magicNumber,
       },
       result: result,
     );
   }
 
   Future<String> pushAndRemoveUntilToScreenOne<TO extends Object>(
-      {@required String testId, @required RoutePredicate predicate}) {
+      {@required String testId,
+      int magicNumber,
+      @required RoutePredicate predicate}) {
     return nuvigator.pushNamedAndRemoveUntil<String>(
       SampleOneRoutes.screenOne,
       predicate,
       arguments: {
         'testId': testId,
+        'magicNumber': magicNumber,
       },
     );
   }
 
   Future<String> popAndPushToScreenOne<TO extends Object>(
-      {@required String testId, TO result}) {
+      {@required String testId, int magicNumber, TO result}) {
     return nuvigator.popAndPushNamed<String, TO>(
       SampleOneRoutes.screenOne,
       arguments: {
         'testId': testId,
+        'magicNumber': magicNumber,
       },
       result: result,
     );
@@ -119,8 +134,8 @@ extension SampleOneRouterScreensAndRouters on SampleOneRouter {
     return {
       RouteDef(SampleOneRoutes.screenOne, deepLink: '/screenOne/:testId'):
           (RouteSettings settings) {
-        final Map<String, Object> args = settings.arguments;
-        return screenOne(testId: args['testId']);
+        final args = ScreenOneArgs.parse(settings.arguments);
+        return screenOne(testId: args.testId, magicNumber: args.magicNumber);
       },
       RouteDef(SampleOneRoutes.screenTwo): (RouteSettings settings) {
         return screenTwo();

--- a/example/lib/samples/modules/sample_one/screen/screen_one.dart
+++ b/example/lib/samples/modules/sample_one/screen/screen_one.dart
@@ -1,12 +1,18 @@
 import 'package:flutter/material.dart';
 
 class ScreenOne extends StatelessWidget {
-  const ScreenOne({Key key, this.toScreenTwo, this.toSampleTwo, this.toBack})
-      : super(key: key);
+  const ScreenOne({
+    Key key,
+    this.toScreenTwo,
+    this.toSampleTwo,
+    this.toBack,
+    this.magicNumber,
+  }) : super(key: key);
 
   final VoidCallback toScreenTwo;
   final VoidCallback toSampleTwo;
   final VoidCallback toBack;
+  final int magicNumber;
 
   @override
   Widget build(BuildContext context) {
@@ -34,6 +40,7 @@ class ScreenOne extends StatelessWidget {
             child: FlutterLogo(),
             tag: 'HERO',
           ),
+          Text('$magicNumber', textAlign: TextAlign.center),
         ],
       ),
     );

--- a/example/lib/samples/navigation/samples_router.g.dart
+++ b/example/lib/samples/navigation/samples_router.g.dart
@@ -18,6 +18,9 @@ class SecondArgs {
   final String testId;
 
   static SecondArgs parse(Map<String, Object> args) {
+    if (args == null) {
+      return SecondArgs(testId: null);
+    }
     return SecondArgs(
       testId: args['testId'],
     );
@@ -126,8 +129,8 @@ extension SamplesRouterScreensAndRouters on SamplesRouter {
         return home();
       },
       RouteDef(SamplesRoutes.second): (RouteSettings settings) {
-        final Map<String, Object> args = settings.arguments;
-        return second(testId: args['testId']);
+        final args = SecondArgs.parse(settings.arguments);
+        return second(testId: args.testId);
       },
     };
   }

--- a/lib/builder/args_class.dart
+++ b/lib/builder/args_class.dart
@@ -34,7 +34,11 @@ class ArgsClass extends BaseBuilder {
     );
   }
 
-  Method _parseMethod(String className, String argsCode) {
+  Method _parseMethod(
+      String className, String argsCode, List<Field> argsFields) {
+    final emptyConstructorArgs =
+        argsFields.map((a) => '${a.name}: null').join(',');
+
     return Method(
       (m) => m
         ..name = 'parse'
@@ -45,7 +49,11 @@ class ArgsClass extends BaseBuilder {
         )
         ..returns = refer(className)
         ..static = true
-        ..body = Code('return $className($argsCode);'),
+        ..body = Code(
+            'if (args == null) {'
+            'return $className($emptyConstructorArgs);'
+            '}'
+            'return $className($argsCode);'),
     );
   }
 
@@ -101,11 +109,44 @@ class ArgsClass extends BaseBuilder {
         ..constructors.add(_constructor(constructorParameters))
         ..fields.addAll(argsFields)
         ..methods.addAll([
-          _parseMethod(className, argsCode),
+          _parseMethod(className, argsCode, argsFields),
           _toMapMethod(argsFields),
           _ofMethod(className, routerName, fieldName),
         ]),
     );
+  }
+
+  static final _tryParseableTypeNames = [
+    'int',
+    'double',
+    'DateTime',
+  ];
+
+  static final _supportedTypes = [..._tryParseableTypeNames, 'bool', 'String'];
+
+  String _safelyCastArg(ParameterElement arg, MethodElement method) {
+    final varName = arg.name.toString();
+    final typeName = arg.type.toString();
+    final nuRouteFieldAnnotation =
+        nuRouteChecker.firstAnnotationOfExact(method);
+
+    if (!(nuRouteFieldAnnotation?.getField('deepLink')?.isNull ?? true) &&
+        !_supportedTypes.contains(typeName)) {
+      print(
+        'Unsuported type `$typeName` for route argument `$varName` in route `${method.name}` that generates a deep link.\n'
+        'This will throw a runtime error when calling the deep link as the argument will be passed as a `String` to a route that expects a `$typeName`.',
+      );
+    }
+
+    if (_tryParseableTypeNames.contains(typeName)) {
+      return "args['$varName'] is String ? $typeName.tryParse(args['$varName']) : args['$varName']";
+    }
+
+    if (typeName == 'bool') {
+      return "args['$varName'] is String ? boolFromString(args['$varName']) : args['$varName']";
+    }
+
+    return "args['$varName']";
   }
 
   @override
@@ -128,7 +169,7 @@ class ArgsClass extends BaseBuilder {
         final varName = arg.name.toString();
         final typeName = arg.type.toString();
 
-        argsParserBuffer.write("$varName: args['$varName'],\n");
+        argsParserBuffer.write('$varName: ${_safelyCastArg(arg, method)},\n');
 
         constructorParameters.add(
           _constructorParameter(varName),

--- a/lib/builder/builder_library.dart
+++ b/lib/builder/builder_library.dart
@@ -75,7 +75,7 @@ class BuilderLibrary extends BaseBuilder {
             nuRouteFieldAnnotation.getField('deepLink').toStringValue();
         final paramsStr = params.isEmpty
             ? ''
-            : '${params.map((p) => "$p: args['$p']").join(",")}';
+            : '${params.map((p) => "$p: args.$p").join(",")}';
 
         final screenRouteBuilder = Method((m) => m
           ..requiredParameters.add(Parameter((p) => p
@@ -84,7 +84,7 @@ class BuilderLibrary extends BaseBuilder {
           ..lambda = false
           ..body = Code((params.isEmpty
                   ? ''
-                  : 'final Map<String, Object> args = settings.arguments ?? const {};') +
+                  : 'final args = ${capitalize(method.name)}Args.parse(settings.arguments);') +
               'return ${method.name}($paramsStr);'));
 
         if (deepLink != null) {

--- a/lib/nuvigator.dart
+++ b/lib/nuvigator.dart
@@ -1,6 +1,7 @@
 library nuvigator;
 
 export 'src/annotations.dart';
+export 'src/helpers.dart';
 export 'src/nuvigator.dart';
 export 'src/router.dart';
 export 'src/screen_route.dart';

--- a/lib/src/helpers.dart
+++ b/lib/src/helpers.dart
@@ -1,0 +1,10 @@
+bool boolFromString(String boolValue) {
+  switch (boolValue?.toLowerCase()) {
+    case 'true':
+      return true;
+    case 'false':
+      return false;
+    default:
+      return null;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nuvigator
 description: A powerful and strongly typed routing abstraction over Flutter navigator, providing some new features and an easy way to define routers with code generation.
-version: 0.5.1
+version: 0.6.0
 
 homepage: https://github.com/nubank/nuvigator
 

--- a/test/fixtures/test_router.dart
+++ b/test/fixtures/test_router.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:nuvigator/nuvigator.dart';
+
+part 'test_router.g.dart';
+
+@NuRouter()
+class TestRouter extends Router {
+  @NuRoute(deepLink: 'home')
+  ScreenRoute<void> home() => ScreenRoute(
+        builder: (context) => const Text('Home'),
+      );
+
+  @NuRoute(deepLink: 'testargs')
+  ScreenRoute<void> testArgs({
+    int intArg,
+    double doubleArg,
+    bool boolArg,
+    DateTime dateTimeArg,
+    DateTime dateArg,
+    String stringArg,
+  }) =>
+      ScreenRoute(
+        builder: (context) => Column(
+          children: [
+            Text('intArg: $intArg'),
+            Text('doubleArg: $doubleArg'),
+            Text('boolArg: $boolArg'),
+            Text('dateTimeArg: $dateTimeArg'),
+            Text('dateArg: $dateArg'),
+            Text('stringArg: $stringArg'),
+          ],
+        ),
+      );
+
+  @override
+  Map<RouteDef, ScreenRouteBuilder> get screensMap => _$screensMap;
+}

--- a/test/fixtures/test_router.g.dart
+++ b/test/fixtures/test_router.g.dart
@@ -1,0 +1,225 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'test_router.dart';
+
+// **************************************************************************
+// NuvigatorGenerator
+// **************************************************************************
+
+class TestRoutes {
+  static const home = 'test/home';
+
+  static const testArgs = 'test/testArgs';
+}
+
+class TestArgsArgs {
+  TestArgsArgs(
+      {@required this.intArg,
+      @required this.doubleArg,
+      @required this.boolArg,
+      @required this.dateTimeArg,
+      @required this.dateArg,
+      @required this.stringArg});
+
+  final int intArg;
+
+  final double doubleArg;
+
+  final bool boolArg;
+
+  final DateTime dateTimeArg;
+
+  final DateTime dateArg;
+
+  final String stringArg;
+
+  static TestArgsArgs parse(Map<String, Object> args) {
+    if (args == null) {
+      return TestArgsArgs(
+          intArg: null,
+          doubleArg: null,
+          boolArg: null,
+          dateTimeArg: null,
+          dateArg: null,
+          stringArg: null);
+    }
+    return TestArgsArgs(
+      intArg: args['intArg'] is String
+          ? int.tryParse(args['intArg'])
+          : args['intArg'],
+      doubleArg: args['doubleArg'] is String
+          ? double.tryParse(args['doubleArg'])
+          : args['doubleArg'],
+      boolArg: args['boolArg'] is String
+          ? boolFromString(args['boolArg'])
+          : args['boolArg'],
+      dateTimeArg: args['dateTimeArg'] is String
+          ? DateTime.tryParse(args['dateTimeArg'])
+          : args['dateTimeArg'],
+      dateArg: args['dateArg'] is String
+          ? DateTime.tryParse(args['dateArg'])
+          : args['dateArg'],
+      stringArg: args['stringArg'],
+    );
+  }
+
+  Map<String, Object> get toMap => {
+        'intArg': intArg,
+        'doubleArg': doubleArg,
+        'boolArg': boolArg,
+        'dateTimeArg': dateTimeArg,
+        'dateArg': dateArg,
+        'stringArg': stringArg,
+      };
+  static TestArgsArgs of(BuildContext context) {
+    final routeSettings = ModalRoute.of(context)?.settings;
+    final nuvigator = Nuvigator.of(context);
+    if (routeSettings?.name == TestRoutes.testArgs) {
+      final args = routeSettings?.arguments;
+      if (args == null)
+        throw FlutterError('TestArgsArgs requires Route arguments');
+      if (args is TestArgsArgs) return args;
+      if (args is Map<String, Object>) return parse(args);
+    } else if (nuvigator != null) {
+      return of(nuvigator.context);
+    }
+    return null;
+  }
+}
+
+extension TestRouterNavigation on TestRouter {
+  Future<void> toHome() {
+    return nuvigator.pushNamed<void>(
+      TestRoutes.home,
+    );
+  }
+
+  Future<void> pushReplacementToHome<TO extends Object>({TO result}) {
+    return nuvigator.pushReplacementNamed<void, TO>(
+      TestRoutes.home,
+      result: result,
+    );
+  }
+
+  Future<void> pushAndRemoveUntilToHome<TO extends Object>(
+      {@required RoutePredicate predicate}) {
+    return nuvigator.pushNamedAndRemoveUntil<void>(
+      TestRoutes.home,
+      predicate,
+    );
+  }
+
+  Future<void> popAndPushToHome<TO extends Object>({TO result}) {
+    return nuvigator.popAndPushNamed<void, TO>(
+      TestRoutes.home,
+      result: result,
+    );
+  }
+
+  Future<void> toTestArgs(
+      {int intArg,
+      double doubleArg,
+      bool boolArg,
+      DateTime dateTimeArg,
+      DateTime dateArg,
+      String stringArg}) {
+    return nuvigator.pushNamed<void>(
+      TestRoutes.testArgs,
+      arguments: {
+        'intArg': intArg,
+        'doubleArg': doubleArg,
+        'boolArg': boolArg,
+        'dateTimeArg': dateTimeArg,
+        'dateArg': dateArg,
+        'stringArg': stringArg,
+      },
+    );
+  }
+
+  Future<void> pushReplacementToTestArgs<TO extends Object>(
+      {int intArg,
+      double doubleArg,
+      bool boolArg,
+      DateTime dateTimeArg,
+      DateTime dateArg,
+      String stringArg,
+      TO result}) {
+    return nuvigator.pushReplacementNamed<void, TO>(
+      TestRoutes.testArgs,
+      arguments: {
+        'intArg': intArg,
+        'doubleArg': doubleArg,
+        'boolArg': boolArg,
+        'dateTimeArg': dateTimeArg,
+        'dateArg': dateArg,
+        'stringArg': stringArg,
+      },
+      result: result,
+    );
+  }
+
+  Future<void> pushAndRemoveUntilToTestArgs<TO extends Object>(
+      {int intArg,
+      double doubleArg,
+      bool boolArg,
+      DateTime dateTimeArg,
+      DateTime dateArg,
+      String stringArg,
+      @required RoutePredicate predicate}) {
+    return nuvigator.pushNamedAndRemoveUntil<void>(
+      TestRoutes.testArgs,
+      predicate,
+      arguments: {
+        'intArg': intArg,
+        'doubleArg': doubleArg,
+        'boolArg': boolArg,
+        'dateTimeArg': dateTimeArg,
+        'dateArg': dateArg,
+        'stringArg': stringArg,
+      },
+    );
+  }
+
+  Future<void> popAndPushToTestArgs<TO extends Object>(
+      {int intArg,
+      double doubleArg,
+      bool boolArg,
+      DateTime dateTimeArg,
+      DateTime dateArg,
+      String stringArg,
+      TO result}) {
+    return nuvigator.popAndPushNamed<void, TO>(
+      TestRoutes.testArgs,
+      arguments: {
+        'intArg': intArg,
+        'doubleArg': doubleArg,
+        'boolArg': boolArg,
+        'dateTimeArg': dateTimeArg,
+        'dateArg': dateArg,
+        'stringArg': stringArg,
+      },
+      result: result,
+    );
+  }
+}
+
+extension TestRouterScreensAndRouters on TestRouter {
+  Map<RouteDef, ScreenRouteBuilder> get _$screensMap {
+    return {
+      RouteDef(TestRoutes.home, deepLink: 'home'): (RouteSettings settings) {
+        return home();
+      },
+      RouteDef(TestRoutes.testArgs, deepLink: 'testargs'):
+          (RouteSettings settings) {
+        final args = TestArgsArgs.parse(settings.arguments);
+        return testArgs(
+            intArg: args.intArg,
+            doubleArg: args.doubleArg,
+            boolArg: args.boolArg,
+            dateTimeArg: args.dateTimeArg,
+            dateArg: args.dateArg,
+            stringArg: args.stringArg);
+      },
+    };
+  }
+}

--- a/test/navigation_test.dart
+++ b/test/navigation_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nuvigator/nuvigator.dart';
+import 'fixtures/test_router.dart';
+
+void main() {
+  Future pumpApp(WidgetTester tester, Router router, String initialRoute) async {
+    await tester.pumpWidget(MaterialApp(
+      title: 'Test Nuvigator',
+      builder: Nuvigator(
+        screenType: cupertinoDialogScreenType,
+        router: router,
+        initialRoute: initialRoute,
+      ),
+    ));
+  }
+
+  testWidgets('Navigates to deepLink without args', (WidgetTester tester) async {
+    final router = TestRouter();
+    await pumpApp(tester, router, TestRoutes.home);
+    router.openDeepLink<void>(Uri.parse('exapp://testargs'));
+    await tester.pumpAndSettle();
+    expect(find.text('intArg: null'), findsOneWidget);
+  });
+
+  testWidgets('Navigates to deepLink with typed args', (WidgetTester tester) async {
+    final router = TestRouter();
+    await pumpApp(tester, router, TestRoutes.home);
+    router.openDeepLink<void>(Uri.parse('exapp://testargs?intArg=42&doubleArg=-4.2&boolArg=true&dateTimeArg=2020-07-07T12:34:00.000Z&dateArg=2020-08-07&stringArg=testing'));
+    await tester.pumpAndSettle();
+    expect(find.text('intArg: 42'), findsOneWidget);
+    expect(find.text('doubleArg: -4.2'), findsOneWidget);
+    expect(find.text('boolArg: true'), findsOneWidget);
+    expect(find.text('dateTimeArg: 2020-07-07 12:34:00.000Z'), findsOneWidget);
+    expect(find.text('dateArg: 2020-08-07 00:00:00.000'), findsOneWidget);
+    expect(find.text('stringArg: testing'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Previously, if a screen had arguments with types other than strings, a runtime error appeared when opening the route through a deep link. This PR adds support for a few basic types such as int, double, bool and DateTime.

Eventually, this could evolve to accept a custom type mapping