### PR TITLE
Fix a NavigationObserver error when the nuvigator is updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 0.6.1
+- Fix a `NavigationObserver` error when the nuvigator is updated. Now we are reloading the `inheritableObservers` and `StateTracker` when has an update.
+
 ## 0.6.0
 - Add support for typed screen arguments on deep links. In addition to `String`, we now support `int`, `double,` `bool`, and `DateTime`.
 

--- a/lib/src/nuvigator.dart
+++ b/lib/src/nuvigator.dart
@@ -220,9 +220,13 @@ class NuvigatorState<T extends Router> extends NavigatorState
       oldWidget.router.nuvigator = null;
       assert(widget.router.nuvigator == null);
       widget.router.nuvigator = this;
-      widget.observers.add(stateTracker);
-      widget.observers.addAll(_collectObservers().map((f) => f()));
     }
+
+    /// Since every update the observers will be overridden by the constructor
+    /// parameters, the stateTracker and inheritableObservers should be injected
+    /// again.
+    widget.observers.add(stateTracker);
+    widget.observers.addAll(_collectObservers().map((f) => f()));
     super.didUpdateWidget(oldWidget);
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nuvigator
 description: A powerful and strongly typed routing abstraction over Flutter navigator, providing some new features and an easy way to define routers with code generation.
-version: 0.6.0
+version: 0.6.1
 
 homepage: https://github.com/nubank/nuvigator
 


### PR DESCRIPTION
The problem here is that when the navigator is updated the observers property is replaced by the constructor observers. We should re-inject the inheritableObservers and StateTracker when the widget is updated to ensure that everything will work normally.