### PR TITLE
Do not remove nuvigator reference from oldWidget.router on didUpdateWidget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 0.6.2
+- Fix NPE exception when a old instance of router tries calling some methods on it's nuvigator
+
 ## 0.6.1
 - Fix a `NavigationObserver` error when the nuvigator is updated. Now we are reloading the `inheritableObservers` and `StateTracker` when has an update.
 

--- a/lib/src/nuvigator.dart
+++ b/lib/src/nuvigator.dart
@@ -217,7 +217,6 @@ class NuvigatorState<T extends Router> extends NavigatorState
   @override
   void didUpdateWidget(Nuvigator oldWidget) {
     if (oldWidget.router != widget.router) {
-      oldWidget.router.nuvigator = null;
       assert(widget.router.nuvigator == null);
       widget.router.nuvigator = this;
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nuvigator
 description: A powerful and strongly typed routing abstraction over Flutter navigator, providing some new features and an easy way to define routers with code generation.
-version: 0.6.1
+version: 0.6.2
 
 homepage: https://github.com/nubank/nuvigator
 


### PR DESCRIPTION
On some occasions, this was causing a NPE exception because the oldRouter was still referenced across the application.  This PR stops removing the navigator reference from oldRouters so we avoid this kind of problem in some scenarios.