### PR TITLE
LENPLAT-389 Decode uri params

### DIFF
--- a/lib/src/router.dart
+++ b/lib/src/router.dart
@@ -19,7 +19,10 @@ Map<String, String> extractDeepLinkParameters(
   final regExp = pathToRegExp(deepLinkTemplate, parameters: parameters);
   final match = regExp.matchAsPrefix(deepLinkString(url));
   final parametersMap = extract(parameters, match)..addAll(url.queryParameters);
-  final camelCasedParametersMap = parametersMap.map((k, v) {
+  final decodedParametersMap = parametersMap.map((k, v) {
+    return MapEntry(k, Uri.decodeFull(v));
+  });
+  final camelCasedParametersMap = decodedParametersMap.map((k, v) {
     return MapEntry(ReCase(k).camelCase, v);
   });
   return {...parametersMap, ...camelCasedParametersMap};

--- a/lib/src/router.dart
+++ b/lib/src/router.dart
@@ -18,11 +18,14 @@ Map<String, String> extractDeepLinkParameters(
   final parameters = <String>[];
   final regExp = pathToRegExp(deepLinkTemplate, parameters: parameters);
   final match = regExp.matchAsPrefix(deepLinkString(url));
-  final parametersMap = extract(parameters, match)..addAll(url.queryParameters);
-  final adjustParametersMap = parametersMap.map((k, v) {
-    return MapEntry(ReCase(k).camelCase, Uri.decodeFull(v));
+  final parametersMap = extract(parameters, match).map((k, v) {
+    return MapEntry(k, Uri.decodeFull(v));
+  })
+    ..addAll(url.queryParameters);
+  final camelCasedParametersMap = parametersMap.map((k, v) {
+    return MapEntry(ReCase(k).camelCase, v);
   });
-  return {...parametersMap, ...adjustParametersMap};
+  return {...parametersMap, ...camelCasedParametersMap};
 }
 
 class RouteEntry {

--- a/lib/src/router.dart
+++ b/lib/src/router.dart
@@ -19,13 +19,10 @@ Map<String, String> extractDeepLinkParameters(
   final regExp = pathToRegExp(deepLinkTemplate, parameters: parameters);
   final match = regExp.matchAsPrefix(deepLinkString(url));
   final parametersMap = extract(parameters, match)..addAll(url.queryParameters);
-  final decodedParametersMap = parametersMap.map((k, v) {
-    return MapEntry(k, Uri.decodeFull(v));
+  final adjustParametersMap = parametersMap.map((k, v) {
+    return MapEntry(ReCase(k).camelCase, Uri.decodeFull(v));
   });
-  final camelCasedParametersMap = decodedParametersMap.map((k, v) {
-    return MapEntry(ReCase(k).camelCase, v);
-  });
-  return {...parametersMap, ...camelCasedParametersMap};
+  return {...parametersMap, ...adjustParametersMap};
 }
 
 class RouteEntry {

--- a/test/router_test.dart
+++ b/test/router_test.dart
@@ -107,5 +107,15 @@ void main() {
         'anotherOne': 'hello'
       });
     });
+    test('it can decode encoded values', () {
+      const uri = 'my-route/5f3fd8d0-d02a-434b-801a-c5c3d12faef6/another%20one';
+      const deepLinkTemplate = 'my-route/:id/:paramName';
+      final result =
+          extractDeepLinkParameters(Uri.parse(uri), deepLinkTemplate);
+      expect(result, {
+        'id': '5f3fd8d0-d02a-434b-801a-c5c3d12faef6',
+        'paramName': 'another one'
+      });
+    });
   });
 }


### PR DESCRIPTION
This PR decode the parameters encoded sent to the DeepLinks.

We were having decode problems when sent an expression with blanc space ( ) or acute accent (´) as param in a deepLink uri parameter.

e.g: 
`Dinheiro%20do%20caf%C3%A9` should return `Dinheiro do café`