### PR TITLE
Reword README and remove FlowRoute mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,8 @@ Routing and Navigation package.
 
 ## What
 
-This package aims to provide a powerful routing abstraction over Flutter Navigators. Using a most declarative and concise
-approach you will be able to model complex navigation flows without needing to worry about several tricky behaviours
-that the framework will handle for you.
-
-Below you will find a description of the main components of this frameworks,
-and how you can use they in your project.
+Nuvigator provides a powerful routing abstraction over Flutter's own Navigators. Model complex navigation flows using a mostly
+declarative and concise approach, without needing to worry about several tricky behaviours that Nuvigator handles for you.
 
 ## Main Concepts
 
@@ -63,53 +59,46 @@ class MyApp extends StatelessWidget {
 
 ```
 
-## Nuvigator
+## Nuvigator and Router
 
-`Nuvigator` is a custom `Navigator`, it behaves just like a normal `Navigator`, but with several custom improvements and
-features. It is engineered specially to work under nested scenarios, where you can have several Flows one inside another,
-it will event ensure that your Hero transitions work well under those scenarios. `Nuvigator` will be your main interface 
-to interact with navigation, and  it can be easily fetched from the context, just like a normal `Navigator`, ie: `Nuvigator.of(context)`.
+`Nuvigator` is a custom `Navigator`. It behaves just like a normal `Navigator`, but has several custom improvements and
+features. It is engineered specially to work under nested scenarios, where you can have several Flows one inside another.
+It also ensures your Hero transitions work well under these scenarios. `Nuvigator` is your main interface to interact with
+navigation, and it can be easily fetched from the context, just like a normal `Navigator`, using `Nuvigator.of(context)`.
 
-Nuvigator includes several extra methods that can be used, for example the `Nuvigator.of(context).openDeepLink()` methods
-that will try to open the desired deepLink. Or event the `Nuvigator.of(context).closeFlow()` that will try to close a nested
-Nuvigator.
+Nuvigator includes several extra methods, like `Nuvigator.of(context).openDeepLink()` that tries to open the desired deep link.
+Another example is `Nuvigator.of(context).closeFlow()` that tries to close all screens of a nested Nuvigator.
 
-Each `Nuvigator` should have a `Router`. The `Router` acts just like the routing controller. While the `Nuvigator` will
-be responsible for visualization, widget render and state keeping. The Router will be Pure class that will be responsible
-to provide elements to be presented and managed by the Nuvigator.
+Each `Nuvigator` should have a `Router`. The `Router` acts as a routing controller. A `Nuvigator` is responsible for
+visualization, widget rendering and state keeping. A Router is a Pure class that is responsible for providing elements to
+be presented and managed by the Nuvigator.
 
-## ScreenRoute and FlowRoute
+## ScreenRoute
 
-Envelopes a widget that is going to be presented as a Screen by a Nuvigator. The Screen contains a ScreenBuilder 
-function, and some attributes, like screenType, that are going to be used to generate a route properly.
+`ScreenRoute` envelopes a widget that is going to be presented as a Screen by a Nuvigator. The Screen contains a ScreenBuilder 
+function and some attributes, like `screenType`, that are going to be used to generate a route properly.
 
-When creating a `ScreenRoute` it can receive a optional generic type that will be considered as the type of the value
+When creating a `ScreenRoute` it can receive an optional generic type that is considered as the type of the value
 to be returned by this Route when popped.
 
 Screen Options:
 
-- builder
-- screenType
-- wrapper
+- `builder`: takes in the `context` and returns the widget to be presented as the Screen of the route.
+- `screenType`: describes how the screen should be presented.
+- `wrapper`: optionally wrap the widgets returned by `builder`. Takes in the `context` and a `child`.
 
-FlowRoute is just a subclass of the `ScreenRoute` that may receive a `Nuvigator` instead of a builder function. Using
-the FlowRoute will allow Nuvigator to properly create all nested Nuvigator routing methods correctly.
-
-When using `FlowRoute` you **SHOULD** declare the generic type of the `Router` that is being used by it's Nuvigator. This
-is required so the static analysis is able to properly generate the code when running the builder.
+A `ScreenRoute` may return another `Nuvigator`. This is useful for defining a nested flow that, when finished, can dismiss itself.
 
 ## Creating Routers
 
-Defining a new Router will probably be the what you will do the most when working with Nuvigator, so understanding how
-to do it properly is important. A Router class is a class that should extend a `Router` and annotate the class with 
-the `@NuRouter` annotation.
+Defining a new Router is probably be the what you will do the most when working with Nuvigator, so understanding how
+to do it properly is important. A Router class is a class that extends a `Router` and is annotated with the `@NuRouter` annotation.
 
 ### Defining Routes
  
-Inside your `MyCustomRouter` you can define your routes, each route will be represented by a
-method annotated with the `@NuRoute` annotation. Those methods should return a `ScreenRoute` or a `FlowRoute`, and can
-receive any number of **named** arguments, those will be used as the Arguments that should/can be passed to your route
-when navigating to it.
+In the example, inside your `MyCustomRouter` we define our routes. Each route is represented by a method annotated with the `@NuRoute`
+annotation. These methods should return a `ScreenRoute` and can receive any number of **named** arguments. These arguments are used as
+the Arguments that can be passed to your route when navigating to it.
 
 Example:
 ```dart
@@ -127,28 +116,46 @@ class MyCustomRouter extends Router {
 }
 ```
 
-### DeepLinks
+### Deep links
 
-The `NuRoute` annotation may receive some options, in special, the `deepLink` option is used to declare a deepLink that
-will be used to access this route. The usage is the same when using a `FlowRoute`, the only changes will be in the generated
-code, that will take in account the nested nuvigator.
+The `NuRoute` annotation may receive some options. In particular, the `deepLink` option is used to declare a deep link that
+can be used to access this route. The usage is the same when using a nested nuvigator, the only changes are in the generated
+code, that takes into account the nesting and properly defines the deep link path.
 
-DeepLinks support both pathParameters (using URL templates) and queryParameters. Those parameters will be passed to your
-Route as arguments as Strings, so keep that in mind when declaring the Route arguments.
+Deep links support both `pathParameters` (using URL templates) and `queryParameters`. Depending on the type of these parameters,
+they'll be passed to the Route's arguments either as their proper type or as Strings. Currently, Nuvigator can handle the following
+types natively for parameters in a deep link:
+
+- int (`?number=42`)
+- double (`?number=42.5`)
+- bool (`?active=true`, `?active=false`)
+- DateTime (`?date=2020-10-01`, `?date=2020-10-01T15:32:09.123Z`)
+- String (`?name=Jane+Doe`)
+
+Any of these **can be null** if you try to open a deep link without specifing them **or if they fail to parse** (e.g. `falseee` as
+a bool outputs `null`).
+
+If you create a Route that takes an argument of a different type and it has a deep link, Nuvigator's code generation tool will issue
+a warning about it. This is because, when decoding something that is not declared as one of these types, the result **will be a String**.
+When you open the route using a function call, it expects the properly typed argument but when opening via deep link it receives
+a String.
+
+As of now, if you want a route to have a deep link and it takes parameters of types not in the list above, the safest solution is expecting
+a String and doing the parsing in the Route. We don't have yet a way to define custom parsing for different types. This issue does not
+exist if the route does not declare a deep link.
 
 Example:
 ```dart
 @NuRoute(deepLink: 'myRoute/:argumentName')
 ```
 
-_Obs_: DeepLinks contained in routers that are used in nested Nuvigators (inside a `FlowRoute`) will **NOT** be considered
-and are not reachable. If you want to create a deepLink to a flow, be sure to add it to the `@NuRoute` annotation in the 
-Router that declares the `FlowRoute`.
+ℹ️ Note: Deep links contained in routers that are used in nested Nuvigators will **not** be considered and are not reachable. If you
+want to create a deepLink to a flow, be sure to add it to the `@NuRoute` annotation in the Router that declares the nested `Nuvigator`.
 
 ### Grouped Routers
 
-In addition to declaring Routes in your Router, you can also declare child Routers. Those routers will have it's Routes
-presented as being part of the father Router. We may also refer this pattern as Router Grouping or Grouped Routers.
+In addition to declaring Routes in your Router, you can also declare child Routers. These routers have its Routes
+presented as being part of the parent Router. We may also refer this pattern as Router Grouping or Grouped Routers.
 This allows for splitting a huge router that potentially could have many Routes, into smaller autonomous Routers that can
 be imported and grouped together in the main Router.
 
@@ -175,39 +182,41 @@ class MyCustomRouter extends Router {
 When extending from the `Router` you can override the following properties to add custom behaviors to your routes:
 
 - `deepLinkPrefix`:
-A `Future<String>`, that will be used as prefix for the deepLinks declared on each route, and also on the grouped routers.
+A `Future<String>`, that is used as prefix for the deep links declared on each route, and also for the grouped routers.
 
 - `screensWrapper`:
 A function to wrap each route presented by this router. Should return a new Widget that wraps this child Widget. 
-The Wrapper will be applied to all Screens in this Router. (this function runs one time for each screen, and not one 
-time for the entire Router).
+The Wrapper is applied to all Screens in this Router. This function runs one time for each screen, and not one 
+time for the entire Router.
 
 - `routers`
 Sub-Routers grouped into this Router.
 
 ## Code Generators
 
-You probably noted in the examples above that we have methods that will be created by the Nuvigator generator. So while
+You may have noticed in the examples above that we have methods that will be created by the Nuvigator generator. So while
 they don't exists you can just make they return `null` or leave un-implemented. 
 
 Before running the generator we recommend being sure that each Router is in a separated file, and also make sure that you
 have added the `part 'my_custom_router.g.dart';` directive and the required imports (`package:nuvigator/nuvigator.dart` and `package:flutter/widgets.dart`) in your router file. 
 
-After running the generator (`flutter pub run build_runner build --delete-conflicting-outputs`), you will notice that 
-each router file will have it's part of file created. Now you can complete the `screensMap` and `routersList` functions
-with the generated: `_$myScreensMap(this);` and `_$samplesRoutersList(this);`. Generated code will usually follow this pattern
+After running the generator (`flutter pub run build_runner build --delete-conflicting-outputs`), you should notice that 
+each router file will have its `part-of` file created. Now you can complete the `screensMap` and `routersList` functions
+with the generated: `_$myScreensMap(this);` and `_$samplesRoutersList(this);`. Generated code usually follows this pattern
 of stripping out the `Router` part of your Router class and using the rest of the name for generated code.
 
 Generated code includes the following features:
 
-- Routes "enum" class
+- Routes Enum-like class
 - Navigation extension methods to Router
 - Typed Arguments classes
 - Implementation Methods
 
 ### Routes Class
 
-The Routes Class is a "enum" like class, that contains mapping to the generated route names for your router, eg:
+The Routes Class is an autogenerated Enum-like class that contains a mapping to the generated route names for your router.
+You can use it as a way of not hardcoding route names.
+
 ```dart
 class SamplesRoutes {
   static const home = 'samples/home';
@@ -218,8 +227,8 @@ class SamplesRoutes {
 
 ### Typed Argument Classes
 
-Those are classes representing the arguments each route can receive. They include parse methods to extract itself from
-the BuildContext. eg:
+These are classes representing the arguments each route can receive. They include parse methods to extract themselves from
+the BuildContext.
 
 ```dart
 class SecondArgs {
@@ -243,7 +252,7 @@ It's a helper class that contains a bunch of typed navigation methods to navigat
 will have several methods created, each for one of the existing push methods. You can also configure which methods you want
 to generate using the `@NuRoute.pushMethods` parameter.
 
-Nested flows (declared with the `FlowRoute`) will also have it's generated Navigation Class instance provided as a field
+Nested flows (declared with nested Nuvigators) will also have their generated Navigation Class instance provided as a field
 in the parent Navigation. The same applies for Grouped Routers. Usage eg:
 
 ```dart
@@ -251,4 +260,3 @@ final router = Router.of<SamplesRouter>(context);
 await router.sampleOneRouter.toScreenOne(testId: 'From Home');
 await router.toSecond(testId: 'From Home');
 ```
-


### PR DESCRIPTION
This PR updates the README, both with proof-reading to make it more consistent and with removal of outdated constructs such as `FlowRoute`. It also adds information about typed parameters for deep links (added in v.6.0 and not yet documented).