### PR TITLE
Fix the nu route settings copy methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.0.0-beta.8
+- Fix the NuRouteSettings copy and fallback methods that were not considering the settings property
+
 ## 1.0.0-beta.7
 - Allow specifying which push method to use when calling [NuvigatorState.open]
 

--- a/lib/src/screen_route.dart
+++ b/lib/src/screen_route.dart
@@ -44,6 +44,7 @@ class ScreenRoute<T extends Object> {
       debugKey: debugKey,
       screenType: screenType ?? fallbackScreenType,
       wrapper: wrapper,
+      nuRouteSettings: nuRouteSettings,
     );
   }
 
@@ -55,12 +56,14 @@ class ScreenRoute<T extends Object> {
     WrapperFn wrapper,
     String debugKey,
     String deepLink,
+    NuRouteSettings nuRouteSettings,
   }) {
     return ScreenRoute<T>(
       builder: builder ?? this.builder,
       screenType: screenType ?? this.screenType,
       wrapper: wrapper ?? this.wrapper,
       debugKey: debugKey ?? this.debugKey,
+      nuRouteSettings: nuRouteSettings ?? this.nuRouteSettings,
     );
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nuvigator
 description: A powerful and strongly typed routing abstraction over Flutter navigator, providing some new features and an easy way to define routers with code generation.
-version: 1.0.0-beta.7
+version: 1.0.0-beta.8
 
 homepage: https://github.com/nubank/nuvigator
 


### PR DESCRIPTION
The fallback and copy methods were not considering the settings and the result is the final route without settings