### PR TITLE
Fix problem of extra parameters now being propagated correctly downstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.0.0-beta.10
+- Fix extra arguments passing on the [NuvigatorState.open] method
+
 ## 1.0.0-beta.9
 - Fix open method in order to transport params through actions
 

--- a/lib/src/deeplink.dart
+++ b/lib/src/deeplink.dart
@@ -73,18 +73,15 @@ class DeepLinkParser<A extends Object> {
   }) {
     final qParams = getQueryParams(deepLink);
     final pParams = getPathParams(deepLink);
-    final allParams = <String, dynamic>{
-      ...qParams ?? const <String, dynamic>{},
-      ...pParams ?? const <String, dynamic>{},
-    };
+    final eParams = <String, dynamic>{};
     A parsedArgs;
 
     if (arguments != null) {
       if (arguments is Map<String, dynamic>) {
-        allParams.addAll(arguments);
+        eParams.addAll(arguments);
       } else if (arguments is A) {
         debugPrint('The provided extra argument $arguments is of type $A.'
-            ' Ignoring all deepLink encoded parameters ($allParams) for parsing purposes.');
+            ' Ignoring all deepLink encoded parameters for parsing purposes.');
         parsedArgs = arguments;
       } else {
         throw FlutterError(
@@ -94,11 +91,18 @@ class DeepLinkParser<A extends Object> {
       }
     }
 
+    final allParams = <String, dynamic>{
+      ...qParams ?? const <String, dynamic>{},
+      ...pParams ?? const <String, dynamic>{},
+      ...eParams ?? const <String, dynamic>{},
+    };
+
     return NuRouteSettings(
       name: deepLink,
       pathTemplate: template,
       queryParameters: qParams,
       pathParameters: pParams,
+      extraParameters: eParams,
       arguments: parsedArgs ?? parseParams(allParams),
       scheme: getScheme(deepLink),
     );

--- a/lib/src/nu_route_settings.dart
+++ b/lib/src/nu_route_settings.dart
@@ -10,21 +10,20 @@ class NuRouteSettings<A extends Object> extends RouteSettings {
     this.pathTemplate,
     this.queryParameters = const <String, dynamic>{},
     this.pathParameters = const <String, dynamic>{},
+    this.extraParameters = const <String, dynamic>{},
   }) : super(name: name, arguments: arguments);
 
   final String pathTemplate;
   final String scheme;
   final Map<String, dynamic> queryParameters;
   final Map<String, dynamic> pathParameters;
+  final Map<String, dynamic> extraParameters;
 
   Map<String, dynamic> get rawParameters {
     return <String, dynamic>{
       ...queryParameters ?? const <String, dynamic>{},
       ...pathParameters ?? const <String, dynamic>{},
-      ...arguments is Map<String, dynamic>
-          // ignore: avoid_as
-          ? arguments as Map<String, dynamic>
-          : const <String, dynamic>{},
+      ...extraParameters ?? const <String, dynamic>{},
     };
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nuvigator
 description: A powerful and strongly typed routing abstraction over Flutter navigator, providing some new features and an easy way to define routers with code generation.
-version: 1.0.0-beta.9
+version: 1.0.0-beta.10
 
 homepage: https://github.com/nubank/nuvigator
 


### PR DESCRIPTION
When passing extra arguments to the `open` method, they were not being added to the `rawParameters` if not parsed