### PR TITLE
Changes to explain better a usage of nuvigator

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Basic usage
 import 'package:flutter/widgets.dart';
 import 'package:nuvigator/nuvigator.dart';
 
+part 'my_screen.g.dart';
+
 class MyScreen extends StatelessWidget {
 
   @override
@@ -58,6 +60,11 @@ class MyApp extends StatelessWidget {
 }
 
 ```
+
+It's necessary add the dependency [build_runner](https://pub.dev/packages/build_runner) in `pubspec.yaml`.  
+
+Then, run in your command line tool: `flutter pub run build_runner build --delete-conflicting-outputs`. 
+Now, you've a route file `my_screen.g.dart` generated using `Nuvigator` for the class `MyScreen`!
 
 ## Nuvigator and NuRouter
 


### PR DESCRIPTION
With these changes, novice users can better understand how to use nuvigator from scratch. For those who have never used it before, the example "sample" can become a bit confusing because it does not correctly explain the import part of the generated file and how to generate this file. If we explain just at the end of README.md how to use build_runner, the rest of the information ends up shuffling the understanding of how to create a simple route scheme. As it is now, beginners and advanced users can understand, thus, making the documentation more accessible.