### PR TITLE
Bump libs

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,19 +5,19 @@ version: 1.0.0-beta.12
 homepage: https://github.com/nubank/nuvigator
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.6.0 <3.0.0'
 
 dependencies:
   analyzer: ^1.0.0
-  build: ^2.0.0
+  build: '>=0.12.6 <2.0.0'
   build_config: '>=0.2.6 <0.5.0'
   code_builder: ^3.2.0
-  dart_style: ^2.0.0
+  dart_style: '>=1.2.9 <1.4.0'
   flutter:
     sdk: flutter
   path_to_regexp: ^0.4.0
   recase: 4.0.0-nullsafety.0
-  source_gen: ^1.0.0
+  source_gen: '>=0.9.4+4 <0.10.0'
 
 dev_dependencies:
   build_runner: ^1.6.5
@@ -25,5 +25,3 @@ dev_dependencies:
     sdk: flutter
   mockito: ^5.0.0
   pedantic: ^1.9.0
-
-

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,23 +5,25 @@ version: 1.0.0-beta.12
 homepage: https://github.com/nubank/nuvigator
 
 environment:
-  sdk: '>=2.6.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  build: '>=0.12.6 <2.0.0'
-  recase: '>=2.0.0 <3.1.0'
+  analyzer: ^1.0.0
+  build: ^2.0.0
   build_config: '>=0.2.6 <0.5.0'
   code_builder: ^3.2.0
-  source_gen: '>=0.9.4+4 <0.10.0'
-  analyzer: '>=0.38.5 <0.41.0'
-  dart_style: '>=1.2.9 <1.4.0'
+  dart_style: ^2.0.0
   flutter:
     sdk: flutter
-  path_to_regexp: ^0.3.0
+  path_to_regexp: ^0.4.0
+  recase: 4.0.0-nullsafety.0
+  source_gen: ^1.0.0
 
 dev_dependencies:
-  mockito: ^4.1.1
-  pedantic: ^1.9.0
   build_runner: ^1.6.5
   flutter_test:
     sdk: flutter
+  mockito: ^5.0.0
+  pedantic: ^1.9.0
+
+


### PR DESCRIPTION
Use the last version of the libs.
The idea is to move in the direction to use nullsafety.

Some dependencies still prevent nuvigator to use nullsafety:
```
dart pub outdated --mode=null-safety
Showing dependencies that are currently not opted in to null-safety.
[✗] indicates versions without null safety support.
[✓] indicates versions opting in to null safety.

Package Name  Current  Upgradable  Resolvable  Latest   

direct dependencies:
build_config  ✗0.4.7   ✗0.4.7      ✗0.4.7      ✗0.4.7   
code_builder  ✗3.7.0   ✗3.7.0      ✗3.7.0      ✗3.7.0   

dev_dependencies:
build_runner  ✗1.12.2  ✗1.12.2     ✗1.12.2     ✗1.12.2  
You are already using the newest resolvable versions listed in the 'Resolvable' column.
Newer versions, listed in 'Latest', may not be mutually compatible.
```