### PR TITLE
Improve screenType options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.1.0
+- Add the `ScreenTypeBuilder` class to allow the definition and creation of `ScreenTypes` in an ad-hoc manner
+- Add the `screenType` parameter to the `NuvigatorState.open` method, allowing to override the `ScreenType` of a defined Route to be opened
+
 ## 1.0.0
 - First stable release with NEXT API (check past beta changelog entries for details)
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -21,7 +21,7 @@ include: package:pedantic/analysis_options.yaml
 
 analyzer:
   strong-mode:
-    implicit-dynamic: false
+    implicit-dynamic: true
   errors:
     # treat missing required parameters as a warning (not a hint)
     missing_required_param: warning

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -54,7 +54,7 @@ linter:
     # - always_specify_types
     - annotate_overrides
     # - avoid_annotating_with_dynamic # conflicts with always_specify_types
-    - avoid_as
+    # - avoid_as
     - avoid_bool_literals_in_conditional_expressions
     # - avoid_catches_without_on_clauses # we do this commonly
     # - avoid_catching_errors # we do this commonly

--- a/example/lib/samples/router.dart
+++ b/example/lib/samples/router.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:nuvigator/next.dart';
@@ -89,7 +90,9 @@ class MainAppRouter extends NuRouter {
         NuRouteBuilder(
           path: 'home',
           builder: (_, __, ___) => HomeScreen(),
-          screenType: materialScreenType,
+          screenType: ScreenTypeBuilder(
+            (WidgetBuilder builder, RouteSettings _) => CupertinoPageRoute(builder: builder),
+          ),
         ),
         FriendRequestRoute(),
         ComposerRoute(),

--- a/example/lib/samples/router.dart
+++ b/example/lib/samples/router.dart
@@ -91,7 +91,8 @@ class MainAppRouter extends NuRouter {
           path: 'home',
           builder: (_, __, ___) => HomeScreen(),
           screenType: ScreenTypeBuilder(
-            (WidgetBuilder builder, RouteSettings _) => CupertinoPageRoute(builder: builder),
+            (WidgetBuilder builder, RouteSettings _) =>
+                CupertinoPageRoute(builder: builder),
           ),
         ),
         FriendRequestRoute(),

--- a/example/lib/samples/screens/home_screen.dart
+++ b/example/lib/samples/screens/home_screen.dart
@@ -44,7 +44,9 @@ class HomeScreen extends StatelessWidget {
                     String text;
 
                     text = await nuvigator.open<String>(
-                        'exapp://composer/text?initialText=Hello+deep+link%21');
+                      'exapp://composer/text?initialText=Hello+deep+link%21',
+                      screenType: cupertinoDialogScreenType,
+                    );
 
                     if (text != null) {
                       // ignore: unawaited_futures

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
 
   nuvigator:
     path: ../
-  provider: ^3.2.0
+  provider: ^4.3.3
 
 dev_dependencies:
   build_runner: ^1.5.0

--- a/lib/src/legacy_nurouter.dart
+++ b/lib/src/legacy_nurouter.dart
@@ -182,12 +182,14 @@ abstract class NuRouter implements INuRouter {
     Object parameters,
     bool isFromNative = false,
     @deprecated bool fromLegacyRouteName = false,
+    ScreenType overrideScreenType,
     ScreenType fallbackScreenType = materialScreenType,
   }) {
     if (fromLegacyRouteName) {
       final settings = RouteSettings(name: deepLink, arguments: parameters);
       return getScreen(settings)
           ?.fallbackScreenType(fallbackScreenType)
+          ?.copyWith(screenType: overrideScreenType)
           ?.toRoute(settings);
     }
     // 1. Get ScreeRouter for DeepLink

--- a/lib/src/next/v1/nu_router.dart
+++ b/lib/src/next/v1/nu_router.dart
@@ -259,12 +259,16 @@ abstract class NuRouter implements INuRouter {
     Object parameters,
     @deprecated bool fromLegacyRouteName = false,
     bool isFromNative = false,
+    ScreenType overrideScreenType,
     ScreenType fallbackScreenType,
   }) {
     final route = _getScreenRoute<R>(
       deepLink,
       parameters: parameters ?? <String, dynamic>{},
-    )?.fallbackScreenType(fallbackScreenType ?? screenType)?.toRoute();
+    )
+        ?.fallbackScreenType(fallbackScreenType ?? screenType)
+        ?.copyWith(screenType: overrideScreenType)
+        ?.toRoute();
     if (route != null) {
       if (isFromNative) {
         _addNativePopCallBack(route);

--- a/lib/src/nuvigator.dart
+++ b/lib/src/nuvigator.dart
@@ -77,6 +77,7 @@ abstract class INuRouter {
     bool fromLegacyRouteName = false,
     bool isFromNative = false,
     ScreenType fallbackScreenType,
+    ScreenType overrideScreenType,
   });
 }
 
@@ -297,7 +298,7 @@ class NuvigatorState<T extends INuRouter> extends NavigatorState
     }
   }
 
-  /// Prefer using [NuvigatorState.open]
+  /// Prefer using [NuvigatorState.open], `.openDeepLink` does not support opening nested deepLinks
   Future<R> openDeepLink<R>(Uri deepLink, [dynamic arguments]) {
     if (rootRouter is legacy.NuRouter) {
       // ignore: avoid_as
@@ -311,9 +312,13 @@ class NuvigatorState<T extends INuRouter> extends NavigatorState
   /// Open the requested deepLink, if the current Nuvigator is not able to handle
   /// it, and no [INuRouter.onDeepLinkNotFound] is provided, then we try to open the
   /// deepLink in the parent Nuvigator.
+  /// [screenType] argument can be used to override the default screenType provided by the to be opened Route
+  /// [pushMethod] allows for customizing how the new Route will be pushed into the stack
+  /// [parameters] is a helper to inject arguments that would be present in the DeepLink query/path parameters
   Future<R> open<R extends Object>(
     String deepLink, {
     DeepLinkPushMethod pushMethod = DeepLinkPushMethod.Push,
+    ScreenType screenType,
     Map<String, dynamic> parameters,
     bool isFromNative = false,
   }) {
@@ -323,6 +328,7 @@ class NuvigatorState<T extends INuRouter> extends NavigatorState
       isFromNative: isFromNative,
       fromLegacyRouteName: false,
       fallbackScreenType: widget.screenType,
+      overrideScreenType: screenType,
     );
     if (route != null) {
       switch (pushMethod) {

--- a/lib/src/screen_type.dart
+++ b/lib/src/screen_type.dart
@@ -43,3 +43,17 @@ abstract class ScreenType {
   Route<T> toRoute<T extends Object>(
       WidgetBuilder builder, RouteSettings settings);
 }
+
+class ScreenTypeBuilder extends ScreenType {
+  ScreenTypeBuilder(this.builder);
+
+  final Route<dynamic> Function(
+      WidgetBuilder builder, RouteSettings setting) builder;
+
+  @override
+  Route<R> toRoute<R extends Object>(
+      WidgetBuilder builder, RouteSettings settings) {
+    // ignore: avoid_as
+    return this.builder(builder, settings) as Route<R>;
+  }
+}

--- a/lib/src/screen_type.dart
+++ b/lib/src/screen_type.dart
@@ -47,8 +47,8 @@ abstract class ScreenType {
 class ScreenTypeBuilder extends ScreenType {
   ScreenTypeBuilder(this.builder);
 
-  final Route<dynamic> Function(
-      WidgetBuilder builder, RouteSettings setting) builder;
+  final Route<dynamic> Function(WidgetBuilder builder, RouteSettings setting)
+      builder;
 
   @override
   Route<R> toRoute<R extends Object>(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nuvigator
 description: A powerful routing abstraction over Flutter navigator, providing some new features and an easy way to define routers.
-version: 1.0.0
+version: 1.1.0
 
 homepage: https://github.com/nubank/nuvigator
 


### PR DESCRIPTION
- Allows overriding the `screenType` when calling the `Nuvigator.open` method
- Created a new class `ScreenTypeBuilder` to allow the creation of anonymous ScreenTypes 