### PR TITLE
Add option to register routes after Router initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 2.0.0-beta.1
+- Add option to get registered routes after NuRouter initialization when overriding the `lazyRouteRegister` option in NuRouter
+
 ## 2.0.0-beta.0
 - Change the `NuRouter.onError` to handle any thrown object (including `Exception`)
 

--- a/doc/next.md
+++ b/doc/next.md
@@ -227,7 +227,7 @@ class MyRouter extends NuRouter {
   DeepLinkHandlerFn get onDeepLinkNotFound => null
 
   // Optional - If the Router initialization fails this function will be called, and it should return a Widget to be rendered instead of the Nuvigator
-  Widget onError(Error error, NuRouterController controller) => null;
+  Widget onError(Object error, NuRouterController controller) => null;
 
   // Optional - Register legacy NuRouters
   @override

--- a/doc/next.md
+++ b/doc/next.md
@@ -199,6 +199,11 @@ class MyRouter extends NuRouter {
 
   ];
 
+  // Optional - Makes the `registerRoutes` method be called to create the Route instances only after the
+  // NuRouter has been initialized (instead of when the class instance is created).
+  @override
+  bool get lazyRouteRegister = true;
+
   // Optional - Default ScreenType to be used when a route does not specify
   @override
   ScreenType get screenType => materialScreenType;

--- a/example/lib/samples/router.dart
+++ b/example/lib/samples/router.dart
@@ -55,11 +55,18 @@ class MainAppRouter extends NuRouter {
   @override
   ScreenType get screenType => cupertinoScreenType;
 
-  // @override
-  // Future<void> init(BuildContext context) {
-  //   throw FlutterError('aaaa');
-  //   return super.init(context);
-  // }
+  List<NuRoute> _postInitRoutes;
+
+  @override
+  Future<void> init(BuildContext context) async {
+    _postInitRoutes = [
+      FriendRequestRoute(),
+      ComposerRoute(),
+    ];
+  }
+
+  @override
+  bool get lazyRouteRegister => true;
 
   @override
   Widget onError(Object error, NuRouterController controller) {
@@ -95,7 +102,6 @@ class MainAppRouter extends NuRouter {
                 CupertinoPageRoute(builder: builder),
           ),
         ),
-        FriendRequestRoute(),
-        ComposerRoute(),
+        ..._postInitRoutes,
       ];
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nuvigator
 description: A powerful routing abstraction over Flutter navigator, providing some new features and an easy way to define routers.
-version: 2.0.0-beta.0
+version: 2.0.0-beta.1
 
 homepage: https://github.com/nubank/nuvigator
 


### PR DESCRIPTION
Add a new option in the `NuRouter` class to call the `registerRoutes` getter only after the NuRouter was initialized. This allows for creating a NuRouter with Routes that can vary depending on some initialization logic or data fetched during it