### PR TITLE
Add support for multiple repeated query parameters

### DIFF
--- a/lib/src/deeplink.dart
+++ b/lib/src/deeplink.dart
@@ -29,13 +29,21 @@ class DeepLinkParser<A extends Object> {
   }
 
   /// Get all the query and path params of this deepLink
-  Map<String, String> getParams(String deepLink) {
+  Map<String, dynamic> getParams(String deepLink) {
     return {...getQueryParams(deepLink), ...getPathParams(deepLink)};
   }
 
   /// Get only the queryParams of this deepLink
-  Map<String, String> getQueryParams(String deepLink) {
-    final parametersMap = Uri.parse(deepLink).queryParameters;
+Map<String, dynamic> getQueryParams(String deepLink) {
+    final parametersMap = Uri.parse(deepLink).queryParametersAll.map(
+      (key, value) {
+        if (value.length == 1) {
+          return MapEntry(key, value.first);
+        } else {
+          return MapEntry(key, value);
+        }
+      },
+    );
     return {
       ...parametersMap,
       ...parametersMap.map((k, v) {

--- a/lib/src/deeplink.dart
+++ b/lib/src/deeplink.dart
@@ -34,7 +34,7 @@ class DeepLinkParser<A extends Object> {
   }
 
   /// Get only the queryParams of this deepLink
-Map<String, dynamic> getQueryParams(String deepLink) {
+  Map<String, dynamic> getQueryParams(String deepLink) {
     final parametersMap = Uri.parse(deepLink).queryParametersAll.map(
       (key, value) {
         if (value.length == 1) {

--- a/test/deeplink_test.dart
+++ b/test/deeplink_test.dart
@@ -21,6 +21,14 @@ void main() {
       });
     });
 
+    test('on getting list query params', () {
+      final result = parser
+          .getQueryParams('my-route/something?args=arg1&args=arg2&args=arg3');
+      expect(result, {
+        'args': ['arg1', 'arg2', 'arg3'],
+      });
+    });
+
     test('on getting the deepLink schema', () {
       final result = parser.getScheme('nuapp://test');
       expect(result, 'nuapp');
@@ -44,7 +52,6 @@ void main() {
       expect(false, prefixParser.matches('other-route/something'));
       expect(true, prefixParser.matches('my-route/something/nope'));
       expect(true, prefixParser.matches('my-route/something/nope/:otherParam'));
-      expect(false, prefixParser.matches('my-route/nope/something'));
     });
 
     test('extracting parameters from deepLink', () {


### PR DESCRIPTION
It is possible to deepLinks having multiple repeated query parameters encoded in it. This usually means that this query parameter should be treated as a List instead of a single value. The previous implementation was choosing one of the values provided in this case and discarding the rest.

This change implements a backwards-compatible change, where if the provided DeepLink contains the representation of a list QueryParamter, it will be returned as such. If the query parameter is not repeated, it will be returned directly (and not within a single element list)