### PR TITLE
Add WillPopCallback only if canPop returns true

### DIFF
--- a/example/lib/samples/modules/friend_request/screens/sub_flow/first_screen.dart
+++ b/example/lib/samples/modules/friend_request/screens/sub_flow/first_screen.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:nuvigator/next.dart';
+
+class FirstScreen extends StatelessWidget {
+  const FirstScreen({
+    Key key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: 20.0,
+            vertical: 20.0,
+          ),
+          child: Column(
+            children: [
+              const Center(child: Text('Some random Screen here')),
+              Padding(
+                padding: const EdgeInsets.all(20),
+                child: Column(
+                  children: [
+                    ElevatedButton(
+                      onPressed: () => Nuvigator.of(context).pushNamed('sub_flow/second_screen'),
+                      child: const Text('Next screen'),
+                    )
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/samples/modules/friend_request/screens/sub_flow/second_screen.dart
+++ b/example/lib/samples/modules/friend_request/screens/sub_flow/second_screen.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:nuvigator/next.dart';
+
+class SecondScreen extends StatelessWidget {
+  const SecondScreen({
+    Key key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: 20.0,
+            vertical: 20.0,
+          ),
+          child: Column(
+            children: [
+              const Center(child: Text('Another random screen')),
+              Padding(
+                padding: const EdgeInsets.all(20),
+                child: Column(
+                  children: [
+                    ElevatedButton(
+                      onPressed: () => Nuvigator.of(context).open(
+                        'exapp://sub_flow/third_screen',
+                      ),
+                      child: const Text('Next screen'),
+                    )
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/samples/modules/friend_request/screens/sub_flow/sub_flow_main.dart
+++ b/example/lib/samples/modules/friend_request/screens/sub_flow/sub_flow_main.dart
@@ -1,0 +1,61 @@
+import 'package:example/samples/modules/friend_request/screens/sub_flow/first_screen.dart';
+import 'package:example/samples/modules/friend_request/screens/sub_flow/second_screen.dart';
+import 'package:example/samples/modules/friend_request/screens/sub_flow/third_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:nuvigator/next.dart';
+
+class SubFlowRoute extends NuRoute {
+  @override
+  ScreenType get screenType => cupertinoScreenType;
+
+  @override
+  Widget build(BuildContext context, NuRouteSettings<Object> settings) {
+    return const SubFlowMain();
+  }
+
+  @override
+  String get path => 'sub_flow';
+}
+
+class SubFlowMain extends StatefulWidget {
+  const SubFlowMain({
+    Key key,
+  }) : super(key: key);
+
+  @override
+  _SubFlowMainState createState() => _SubFlowMainState();
+}
+
+class _SubFlowMainState extends State<SubFlowMain> {
+  @override
+  Widget build(BuildContext context) {
+    return Nuvigator(
+      router: SubFlowRouter(),
+    );
+  }
+}
+
+class SubFlowRouter extends NuRouter {
+  @override
+  ScreenType get screenType => cupertinoScreenType;
+
+  @override
+  String get initialRoute => 'sub_flow/first_screen';
+
+  @override
+  List<NuRoute<NuRouter, Object, Object>> get registerRoutes => [
+        NuRouteBuilder(
+          path: 'sub_flow/first_screen',
+          builder: (_, __, ___) => const FirstScreen(),
+        ),
+        NuRouteBuilder(
+          path: 'sub_flow/second_screen',
+          builder: (_, __, ___) => const SecondScreen(),
+        ),
+        NuRouteBuilder(
+          path: 'sub_flow/third_screen',
+          builder: (_, __, ___) => const ThirdScreen(),
+          screenType: cupertinoDialogScreenType,
+        ),
+      ];
+}

--- a/example/lib/samples/modules/friend_request/screens/sub_flow/third_screen.dart
+++ b/example/lib/samples/modules/friend_request/screens/sub_flow/third_screen.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+class ThirdScreen extends StatelessWidget {
+  const ThirdScreen({
+    Key key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: 20.0,
+            vertical: 20.0,
+          ),
+          child: Column(
+            children: const [
+              Center(child: Text('The last screen but now it is a full screen!')),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/samples/router.dart
+++ b/example/lib/samples/router.dart
@@ -1,3 +1,4 @@
+import 'package:example/samples/modules/friend_request/screens/sub_flow/sub_flow_main.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
@@ -62,6 +63,7 @@ class MainAppRouter extends NuRouter {
     _postInitRoutes = [
       FriendRequestRoute(),
       ComposerRoute(),
+      SubFlowRoute(),
     ];
   }
 

--- a/example/lib/samples/screens/home_screen.dart
+++ b/example/lib/samples/screens/home_screen.dart
@@ -30,7 +30,7 @@ class HomeScreen extends StatelessWidget {
                   textAlign: TextAlign.center,
                 ),
                 const SizedBox(height: 48),
-                RaisedButton(
+                ElevatedButton(
                   onPressed: () {
                     // final r = NuRouter.of<OldFriendRequestRouter>(context);
                     // r.toListRequests();
@@ -39,7 +39,7 @@ class HomeScreen extends StatelessWidget {
                   },
                   child: const Text('Review friend requests'),
                 ),
-                RaisedButton(
+                ElevatedButton(
                   onPressed: () async {
                     String text;
 
@@ -60,6 +60,12 @@ class HomeScreen extends StatelessWidget {
                     }
                   },
                   child: const Text('Compose a message'),
+                ),
+                ElevatedButton(
+                  onPressed: () {
+                    nuvigator.open('expapp://sub_flow');
+                  },
+                  child: const Text('Open a SubFlow'),
                 ),
                 const SizedBox(height: 48),
                 const Text(

--- a/lib/src/nuvigator.dart
+++ b/lib/src/nuvigator.dart
@@ -502,9 +502,11 @@ class NuvigatorState<T extends INuRouter> extends NavigatorState
     }
     if (isNested) {
       child = WillPopScope(
-        onWillPop: () async {
-          return !(await maybePop());
-        },
+        onWillPop: canPop()
+            ? () async {
+                return !(await maybePop());
+              }
+            : null,
         child: child,
       );
     }


### PR DESCRIPTION
With this change a nested Nuvigator will use WillPopScope to override
the pop behavior only when it contains more than route in the history
stack.