### PR TITLE
adding buildWrapper method to nu router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 1.4.2
+## 1.5.0
 - [NEW] Add `NuRoute.metaData` to be used as a metadata dictionary for NuRoutes
 - [NEW] Add `NuRouter.buildWrapper` that can be used to wrap the `builder` function of the registered NuRoutes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.4.2
+- [NEW] Add `NuRoute.metaData` to be used as a metadata dictionary for NuRoutes
+- [NEW] Add `NuRouter.buildWrapper` that can be used to wrap the `builder` function of the registered NuRoutes
+
 ## 1.4.1
 - [FIX] Fix error when disposing a Nuvigator that was rendered in a Route that does not implement `NuvigatorPageRoute`
 

--- a/doc/migrating-to-next-api.md
+++ b/doc/migrating-to-next-api.md
@@ -95,4 +95,5 @@ class MyRoute extends NuRouter {
 
 ## ScreensWrapper
 
-ScreensWrappers were removed to simplify the API design. If you are using it, wrap you widgets in the build method directly instead.
+When using Next API you can override the `buildWrapper` method to wrap the `builder` function of the NuRoutes registered
+in the router with another Widget.

--- a/doc/migrating-to-next-api.md
+++ b/doc/migrating-to-next-api.md
@@ -95,5 +95,4 @@ class MyRoute extends NuRouter {
 
 ## ScreensWrapper
 
-When using Next API you can override the `buildWrapper` method to wrap the `builder` function of the NuRoutes registered
-in the router with another Widget.
+When using Next API you can override the `buildWrapper` method to wrap the `builder` function of the NuRoutes registered in the router with another Widget.

--- a/doc/next.md
+++ b/doc/next.md
@@ -84,6 +84,11 @@ Example:
 
 ```dart
 class MyRoute extends NuRoute<NuRouter, MyArguments, MyReturn> {
+  
+  // Optional - metaData is a `NuRoute` attribute that allows you to provide metadata to the route.   
+  // If not provided via super constructor, it will assume the default value `{}` which can receive data later.
+  MyRoute() : super(metaData: {'foo': 'bar'});
+
   // Optional - If your Router enforces a synchronous initialization this should return an instance of a SynchronousFuture
   @override
   Future<bool> init(BuildContext context) async {
@@ -98,7 +103,7 @@ class MyRoute extends NuRoute<NuRouter, MyArguments, MyReturn> {
   // Optional - converts deepLink params to MyArguments class
   @override
   ParamsParser<MyArguments> get paramsParser => _$paramsParser;
-
+  
   // Optional - The the provided path should be matched as a prefix, instead of exact
   @override
   bool get prefix => false;
@@ -217,6 +222,16 @@ class MyRouter extends NuRouter {
   Future<void> init(BuildContext context) {
     return SynchronousFuture(null);
   }
+
+  // Optional - A function to wrap the `builder` function of the NuRoutes registered in the NuRouter.
+  // This function runs one time for each route, and not one time for the entire NuRouter.
+  Widget buildWrapper(
+      BuildContext context,
+      Widget child,
+      NuRouteSettings settings,
+      NuRoute nuRoute,
+      ) =>
+      child;
 
   // Optional (defaults to true) - Enables/Disables support for asynchronous initialization (will display the loading widget)
   @override

--- a/doc/next_PT.md
+++ b/doc/next_PT.md
@@ -82,6 +82,10 @@ Exemplo:
 
 ```dart
 class MyRoute extends NuRoute<NuRouter, MyArguments, MyReturn> {
+  // Optional - metaData is a `NuRoute` attribute that allows you to provide metadata to the route.   
+  // If not provided via super constructor, it will assume the default value `{}` which can receive data later.
+  MyRoute() : super(metaData: {'foo': 'bar'});
+  
   // Optional - If your Router enforces a synchronous initialization this should return an instance of a SynchronousFuture
   @override
   Future<bool> init(BuildContext context) async {
@@ -210,6 +214,16 @@ class MyRouter extends NuRouter {
   Future<void> init(BuildContext context) {
     return SynchronousFuture(null);
   }
+
+  // Optional - A function to wrap the `builder` function of the NuRoutes registered in the NuRouter.
+  // This function runs one time for each route, and not one time for the entire NuRouter.
+  Widget buildWrapper(
+      BuildContext context,
+      Widget child,
+      NuRouteSettings settings,
+      NuRoute nuRoute,
+      ) =>
+      child;
 
   // Optional (defaults to true) - Enables/Disables support for asynchronous initialization (will display the loading widget)
   @override

--- a/lib/src/next/v1/nu_router.dart
+++ b/lib/src/next/v1/nu_router.dart
@@ -208,7 +208,8 @@ abstract class NuRouter implements INuRouter {
   /// Backwards compatible with old routers API
   List<INuRouter> get legacyRouters => [];
 
-  /// Override if you want to wrap the ScreenRoute with another Widget
+  /// Override if you want to wrap the `builder` function of the NuRoutes
+  /// registered in this router with another Widget
   Widget buildWrapper(
     BuildContext context,
     Widget child,

--- a/lib/src/next/v1/nu_router.dart
+++ b/lib/src/next/v1/nu_router.dart
@@ -12,6 +12,8 @@ import '../../typings.dart';
 /// Extend to create your NuRoute. Contains the configuration of a Route that is
 /// going to be presented in a [Nuvigator] by the [NuRouter]
 abstract class NuRoute<T extends NuRouter, A extends Object, R extends Object> {
+  NuRoute({Map<String, dynamic> metaData}) : metaData = metaData ?? {};
+
   T _router;
 
   T get router => _router;
@@ -25,6 +27,8 @@ abstract class NuRoute<T extends NuRouter, A extends Object, R extends Object> {
   Future<bool> init(BuildContext context) {
     return SynchronousFuture(true);
   }
+
+  final Map<String, dynamic> metaData;
 
   bool get prefix => false;
 
@@ -204,6 +208,15 @@ abstract class NuRouter implements INuRouter {
   /// Backwards compatible with old routers API
   List<INuRouter> get legacyRouters => [];
 
+  /// Override if you want to wrap the ScreenRoute with another Widget
+  Widget buildWrapper(
+    BuildContext context,
+    Widget child,
+    NuRouteSettings settings,
+    NuRoute nuRoute,
+  ) =>
+      child;
+
   /// Override to false if you want a strictly sync initialization in this Router
   /// futures are not going to be awaited to complete!
   bool get awaitForInit => true;
@@ -277,7 +290,14 @@ abstract class NuRouter implements INuRouter {
         deepLink: deepLink,
         extraParameters: parameters,
       );
-      if (screenRoute != null) return screenRoute;
+      if (screenRoute != null) {
+        return screenRoute.wrapWith((context, child) => buildWrapper(
+              context,
+              child,
+              screenRoute.nuRouteSettings,
+              route,
+            ));
+      }
     }
     return null;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nuvigator
 description: A powerful routing abstraction over Flutter navigator, providing some new features and an easy way to define routers.
-version: 1.4.1
+version: 1.4.2
 
 homepage: https://github.com/nubank/nuvigator
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nuvigator
 description: A powerful routing abstraction over Flutter navigator, providing some new features and an easy way to define routers.
-version: 1.4.2
+version: 1.5.0
 
 homepage: https://github.com/nubank/nuvigator
 

--- a/test/next/fixtures/test_next_router.dart
+++ b/test/next/fixtures/test_next_router.dart
@@ -6,6 +6,7 @@ class InitTestNextRouter extends NuRouter {
   InitTestNextRouter({
     @required this.routerInitFuture,
     @required this.routeInitFuture,
+    this.buildWrapperFn,
   })  : assert(routerInitFuture != null),
         assert(routeInitFuture != null);
 
@@ -13,6 +14,12 @@ class InitTestNextRouter extends NuRouter {
 
   final Future<void> Function() routerInitFuture;
   final Future<bool> Function() routeInitFuture;
+  final Widget Function(
+    BuildContext context,
+    Widget child,
+    NuRouteSettings settings,
+    NuRoute nuRoute,
+  ) buildWrapperFn;
 
   @override
   String get initialRoute => initRoute;
@@ -22,6 +29,22 @@ class InitTestNextRouter extends NuRouter {
 
   @override
   ScreenType get screenType => const MaterialScreenType();
+
+  @override
+  Widget buildWrapper(
+    BuildContext context,
+    Widget child,
+    NuRouteSettings settings,
+    NuRoute nuRoute,
+  ) =>
+      buildWrapperFn == null
+          ? child
+          : buildWrapperFn(
+              context,
+              child,
+              settings,
+              nuRoute,
+            );
 
   @override
   Future<void> init(BuildContext context) => routerInitFuture();
@@ -39,4 +62,15 @@ class InitTestNextRouter extends NuRouter {
           initializer: (context) => routeInitFuture(),
         ),
       ];
+}
+
+class FakeWrapper extends StatelessWidget {
+  const FakeWrapper(this._child);
+
+  final Widget _child;
+
+  @override
+  Widget build(BuildContext context) {
+    return _child;
+  }
 }

--- a/test/next/nu_router_init_test.dart
+++ b/test/next/nu_router_init_test.dart
@@ -43,6 +43,26 @@ void main() {
       );
 
       testWidgets(
+        'with success and buildWrapper provided, should wrap and display success widget',
+        (tester) async {
+          final router = InitTestNextRouter(
+              routerInitFuture: () => Future.value(),
+              routeInitFuture: () => Future.value(true),
+              buildWrapperFn: (
+                context,
+                child,
+                settings,
+                nuRoute,
+              ) =>
+                  FakeWrapper(child));
+
+          await pumpFakeApp(tester: tester, router: router);
+          expect(router, isA<FakeWrapper>());
+          expectSuccess(findsOneWidget);
+        },
+      );
+
+      testWidgets(
         'with an exception on router init, should display the error widget',
         (tester) async {
           final exception = Exception();


### PR DESCRIPTION
Introduces `NuRoute.metaData` to be used as a metadata dictionary for NuRoutes
Adds `NuRouter.buildWrapper` that can be used to wrap the `builder` function of the registered NuRoutes