### PR TITLE
Add support for controlling Nuvigator rebuilds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.6.0
+- [ENHANCEMENT] Add `Nuvigator.shouldRebuild` property for controlling when a Nuvigator should be rebuild.
+
 ## 1.5.0
 - [NEW] Add `NuRoute.metaData` to be used as a metadata dictionary for NuRoutes
 - [NEW] Add `NuRouter.buildWrapper` that can be used to wrap the `builder` function of the registered NuRoutes

--- a/lib/src/next/v1/nu_router.dart
+++ b/lib/src/next/v1/nu_router.dart
@@ -414,10 +414,12 @@ class NuRouterLoader extends StatefulWidget {
   const NuRouterLoader({
     Key key,
     this.router,
+    this.shouldRebuild,
     this.builder,
   }) : super(key: key);
 
   final NuRouter router;
+  final ShouldRebuildFn shouldRebuild;
   final Widget Function(NuRouter router) builder;
 
   @override
@@ -458,7 +460,7 @@ class _NuRouterLoaderState extends State<NuRouterLoader> {
 
   @override
   void didUpdateWidget(covariant NuRouterLoader oldWidget) {
-    if (oldWidget.router != widget.router) {
+    if (widget.shouldRebuild(oldWidget.router, widget.router)) {
       _initModule();
       nuvigator = widget.builder(widget.router);
     }

--- a/lib/src/nuvigator.dart
+++ b/lib/src/nuvigator.dart
@@ -512,6 +512,9 @@ class NuvigatorState<T extends INuRouter> extends NavigatorState
   }
 }
 
+bool _defaultShouldRebuild(NuRouter previousRouter, NuRouter newRouter) =>
+    previousRouter != newRouter;
+
 /// Creates a new Nuvigator. When using the Next API, several of those options
 /// are provided by the [NuRouter]. Providing them here will thrown an assertion
 /// error.
@@ -529,6 +532,7 @@ class Nuvigator<T extends INuRouter> extends StatelessWidget {
     this.debug = false,
     this.inheritableObservers = const [],
     this.shouldPopRoot = false,
+    this.shouldRebuild,
   })  : _innerKey = key,
         assert(router != null),
         assert(() {
@@ -549,6 +553,7 @@ class Nuvigator<T extends INuRouter> extends StatelessWidget {
     List<NavigatorObserver> observers = const [],
     bool debug = false,
     bool shouldPopRoot = false,
+    ShouldRebuildFn shouldRebuild,
     Key key,
   }) {
     return Nuvigator(
@@ -557,6 +562,7 @@ class Nuvigator<T extends INuRouter> extends StatelessWidget {
       debug: debug,
       observers: observers,
       shouldPopRoot: shouldPopRoot,
+      shouldRebuild: shouldRebuild,
       router: NuRouterBuilder(
         routes: routes,
         initialRoute: initialRoute,
@@ -576,6 +582,7 @@ class Nuvigator<T extends INuRouter> extends StatelessWidget {
   final String initialRoute;
   final Uri initialDeepLink;
   final Map<String, Object> initialArguments;
+  final ShouldRebuildFn shouldRebuild;
 
   static NuvigatorState ofRouter<T extends INuRouter>(BuildContext context) {
     final closestNuvigator = context.findAncestorStateOfType<NuvigatorState>();
@@ -615,6 +622,7 @@ class Nuvigator<T extends INuRouter> extends StatelessWidget {
     return NuRouterLoader(
       // ignore: avoid_as
       router: router as NuRouter,
+      shouldRebuild: shouldRebuild ?? _defaultShouldRebuild,
       builder: (moduleRouter) => _NuvigatorInner(
         router: moduleRouter,
         debug: debug,

--- a/lib/src/typings.dart
+++ b/lib/src/typings.dart
@@ -28,3 +28,8 @@ typedef NuRouteParametersParser<A> = A Function(Map<String, dynamic>);
 typedef NuInitFunction = Future<bool> Function(BuildContext context);
 
 typedef ParamsParser<T> = T Function(Map<String, dynamic> map);
+
+typedef ShouldRebuildFn = bool Function(
+  NuRouter previousRouter,
+  NuRouter newRouter,
+);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nuvigator
 description: A powerful routing abstraction over Flutter navigator, providing some new features and an easy way to define routers.
-version: 1.5.0
+version: 1.6.0
 
 homepage: https://github.com/nubank/nuvigator
 


### PR DESCRIPTION
This PR introduces the capability for controlling when a Nuvigator should rebuild.

In some cases, for instance, when there's an update in Navigation's stack, we don't want Nuvigators to be rebuild. But, in other cases, where Nuvigator's `NuRouter` is being changed, we want.

The return of `shouldRebuild` method controls if Nuvigator will be rebuilt or not. 