### PR TITLE
Fix NuRouteLoader by caching the NuRouter instead of the Widget

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 job_defaults: &defaults
     docker:
-      - image: cirrusci/flutter
+      - image: cirrusci/flutter:2.2.1
 
 jobs:
   format-check:
@@ -21,7 +21,7 @@ jobs:
     steps:
       - checkout
       - run: flutter pub get
-      - run: flutter test 
+      - run: flutter test
 
 workflows:
   version: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.6.1
+- [FIX] Fix re-renders due to other state changes when `Nuvigator.shouldRebuild` returns false
+
 ## 1.6.0
 - [ENHANCEMENT] Add `Nuvigator.shouldRebuild` property for controlling when a Nuvigator should be rebuild.
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -42,6 +42,7 @@ class MyApp extends StatelessWidget {
         child: ChangeNotifierProvider.value(
           value: FriendRequestBloc(10),
           child: Nuvigator(
+            shouldRebuild: (_, __) => false,
             debug: true,
             router: MainAppRouter(),
           ),

--- a/example/lib/samples/modules/composer/module.dart
+++ b/example/lib/samples/modules/composer/module.dart
@@ -42,6 +42,7 @@ class ComposerRoute extends NuRoute<NuRouter, void, String> {
   @override
   Widget build(BuildContext context, NuRouteSettings<Object> settings) {
     return Nuvigator.routes(
+      shouldRebuild: (_, __) => false,
       initialRoute: settings.name,
       routes: [
         _ComposerHelpRoute(),

--- a/example/lib/samples/modules/composer/screens/help_screen.dart
+++ b/example/lib/samples/modules/composer/screens/help_screen.dart
@@ -8,14 +8,16 @@ class HelpScreen extends StatelessWidget {
       body: const Padding(
         padding: EdgeInsets.all(8),
         child: Text(
-            'You can use the text composer to compose text. It will return the '
-            'text to whoever called this screen when you tap the publish button, '
-            'on the bottom of the Text Field. If you came from the Home screen, '
-            'it will pop up a message on the Home Screen with your composition. '
-            'If you decide to go back instead, it will return null and nothing '
-            'will be displayed. If you did not come from the Home screen, '
-            'nothing will happen either way. Contrary to what it looks like, '
-            'the text will not actually be posted anywhere :)'),
+          'You can use the text composer to compose text. It will return the '
+          'text to whoever called this screen when you tap the publish button, '
+          'on the bottom of the Text Field. If you came from the Home screen, '
+          'it will pop up a message on the Home Screen with your composition. '
+          'If you decide to go back instead, it will return null and nothing '
+          'will be displayed. If you did not come from the Home screen, '
+          'nothing will happen either way. Contrary to what it looks like, '
+          'the text will not actually be posted anywhere :)',
+          style: TextStyle(fontSize: 20),
+        ),
       ),
     );
   }

--- a/lib/src/next/v1/nu_router.dart
+++ b/lib/src/next/v1/nu_router.dart
@@ -427,7 +427,7 @@ class NuRouterLoader extends StatefulWidget {
 }
 
 class _NuRouterLoaderState extends State<NuRouterLoader> {
-  Widget nuvigator;
+  NuRouter router;
   bool loading;
   Widget errorWidget;
 
@@ -437,15 +437,16 @@ class _NuRouterLoaderState extends State<NuRouterLoader> {
 
   Future<void> _initModule() async {
     setState(() {
-      loading = widget.router.awaitForInit;
+      router = widget.router;
+      loading = router.awaitForInit;
       errorWidget = null;
     });
     try {
-      await widget.router._init(context);
+      await router._init(context);
     } catch (error, stackTrace) {
       debugPrintStack(stackTrace: stackTrace, label: error.toString());
       final errorWidget =
-          widget.router.onError(error, NuRouterController(reload: _reload));
+          router.onError(error, NuRouterController(reload: _reload));
       if (errorWidget != null) {
         setState(() {
           this.errorWidget = errorWidget;
@@ -462,7 +463,6 @@ class _NuRouterLoaderState extends State<NuRouterLoader> {
   void didUpdateWidget(covariant NuRouterLoader oldWidget) {
     if (widget.shouldRebuild(oldWidget.router, widget.router)) {
       _initModule();
-      nuvigator = widget.builder(widget.router);
     }
     super.didUpdateWidget(oldWidget);
   }
@@ -476,11 +476,10 @@ class _NuRouterLoaderState extends State<NuRouterLoader> {
   @override
   Widget build(BuildContext context) {
     if (loading) {
-      return widget.router.loadingWidget;
+      return router.loadingWidget;
     } else if (errorWidget != null) {
       return errorWidget;
     }
-    nuvigator ??= widget.builder(widget.router);
-    return nuvigator;
+    return widget.builder(router);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nuvigator
 description: A powerful routing abstraction over Flutter navigator, providing some new features and an easy way to define routers.
-version: 1.6.0
+version: 1.6.1
 
 homepage: https://github.com/nubank/nuvigator
 


### PR DESCRIPTION
The last change that allowed to disable the rebuilds of Nuvigators on certain conditions highlighted a few problems with the current approach of caching the Nuvigator instance, which could cause the App to become non-responsive to other external state changes that should trigger a re-render of the Widget.

This PR aims to fix that by instead caching in the state of the NuRoute instance, and always providing it to the builder function.