### PR TITLE
Update Nuvigator default behavior to not reload when NuRouter changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.7.0-beta.0
+- [FIX] [POSSIBLY BREAKING] Makes the default behavior of Nuvigator to not re-build itself and it's state when the NuRouter provided instance changes. This allows for fixing some state reloads/resets and navigation lost, specially on nested flows. If for some reason you were relying in the current behavior for some feature, you can provide a `shouldRebuild` property to the `Nuvigator` that should return `true` when you wish to perform the rebuild.
+
 ## 1.6.2
 - [FIX] Revert changes from 1.6.1 due to some unexpected behaviors found
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -42,7 +42,6 @@ class MyApp extends StatelessWidget {
         child: ChangeNotifierProvider.value(
           value: FriendRequestBloc(10),
           child: Nuvigator(
-            shouldRebuild: (_, __) => false,
             debug: true,
             router: MainAppRouter(),
           ),

--- a/example/lib/samples/modules/composer/module.dart
+++ b/example/lib/samples/modules/composer/module.dart
@@ -42,7 +42,6 @@ class ComposerRoute extends NuRoute<NuRouter, void, String> {
   @override
   Widget build(BuildContext context, NuRouteSettings<Object> settings) {
     return Nuvigator.routes(
-      shouldRebuild: (_, __) => false,
       initialRoute: settings.name,
       routes: [
         _ComposerHelpRoute(),

--- a/lib/src/nuvigator.dart
+++ b/lib/src/nuvigator.dart
@@ -512,9 +512,6 @@ class NuvigatorState<T extends INuRouter> extends NavigatorState
   }
 }
 
-bool _defaultShouldRebuild(NuRouter previousRouter, NuRouter newRouter) =>
-    previousRouter != newRouter;
-
 /// Creates a new Nuvigator. When using the Next API, several of those options
 /// are provided by the [NuRouter]. Providing them here will thrown an assertion
 /// error.
@@ -622,7 +619,7 @@ class Nuvigator<T extends INuRouter> extends StatelessWidget {
     return NuRouterLoader(
       // ignore: avoid_as
       router: router as NuRouter,
-      shouldRebuild: shouldRebuild ?? _defaultShouldRebuild,
+      shouldRebuild: shouldRebuild,
       builder: (moduleRouter) => _NuvigatorInner(
         router: moduleRouter,
         debug: debug,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nuvigator
 description: A powerful routing abstraction over Flutter navigator, providing some new features and an easy way to define routers.
-version: 1.6.2
+version: 1.7.0-beta.0
 
 homepage: https://github.com/nubank/nuvigator
 

--- a/test/nuvigator_test.dart
+++ b/test/nuvigator_test.dart
@@ -544,9 +544,12 @@ void main() {
   });
 
   testWidgets(
-    'Should rebuild Nuvigator by default when NuRouter instance changes',
+    'Should Nuvigator when shouldRebuild is provided',
     (tester) async {
-      final tracker = await pumpApp(tester);
+      final tracker = await pumpApp(
+        tester,
+        shouldRebuild: (oldRouter, newRouter) => oldRouter != newRouter,
+      );
 
       // Go to Screen3
       unawaited(tracker.rootNuvigator.pushNamed('screen3'));
@@ -580,9 +583,9 @@ void main() {
   );
 
   testWidgets(
-    'Should not rebuild Nuvigator when shouldRebuild returns false',
+    'Should not rebuild Nuvigator by default when shouldRebuild is not provided',
     (tester) async {
-      final tracker = await pumpApp(tester, shouldRebuild: (_, __) => false);
+      final tracker = await pumpApp(tester);
 
       // Go to Screen3
       unawaited(tracker.rootNuvigator.pushNamed('screen3'));


### PR DESCRIPTION
This PR proposes changing the default behavior of Nuvigator to not rebuild/reload from scratch when the NuRouter instance changes, which is especially relevant for nested flow. This is motivated by the following points:

* Development experience is compromised with the current behavior, that without proper state management, at every hot-reload the flow is reset
* Some use cases of nested flows were suffering from resets when the upper state of the tree changed


While we expect this to be a fix/improvement for most cases, it's feasible to this being used as a feature for current users. Due to that, this can be considered a breaking change, and in those cases, you can provide a `shouldRebuild` function to the `Nuvigator` specifying the desired conditions to meet your previous behavior.