### PR TITLE
Add needed paramenters in the readme use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ class MyApp extends StatelessWidget {
       title: 'Nuvigator App',
       builder: Nuvigator.routes(
         initialRoute: 'home',
+        screenType: materialScreenType,
         routes: [
           NuRouteBuilder(path: 'home', builder: (_, __, ___) => HomeScreen()),
           NuRouteBuilder(path: 'second', builder: (_, __, ___) => SecondScreen()),

--- a/README_PT.md
+++ b/README_PT.md
@@ -35,6 +35,7 @@ class MyApp extends StatelessWidget {
       title: 'Nuvigator App',
       builder: Nuvigator.routes(
         initialRoute: 'home',
+        screenType: materialScreenType,
         routes: [
           NuRouteBuilder(path: 'home', builder: (_, __, ___) => HomeScreen()),
           NuRouteBuilder(path: 'second', builder: (_, __, ___) => SecondScreen()),

--- a/doc/next_PT.md
+++ b/doc/next_PT.md
@@ -17,6 +17,7 @@ class MyApp extends StatelessWidget {
       title: 'Nuvigator App',
       builder: Nuvigator.routes(
         initialRoute: 'home',
+        screenType: materialScreenType,
         routes: [
           NuRouteBuilder(path: 'home', builder: (_, __, ___) => HomeScreen()),
           NuRouteBuilder(path: 'second', builder: (_, __, ___) => SecondScreen()),


### PR DESCRIPTION
```dart
class MyApp extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'Nuvigator App',
      builder: Nuvigator.routes(
        initialRoute: 'home',
        screenType: materialScreenType,
        routes: [
          NuRouteBuilder(path: 'home', builder: (_, __, ___) => HomeScreen()),
          NuRouteBuilder(path: 'second', builder: (_, __, ___) => SecondScreen()),
        ],
      ),
    );
  }
}
```

Add the screenType parameter in code above, without it the build fails.