### PR TITLE
Migrate to compatible with Dart 3

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -17,11 +17,11 @@
 #
 # This file contains the analysis options used by Flutter tools, such as IntelliJ,
 # Android Studio, and the `flutter analyze` command.
-include: package:pedantic/analysis_options.yaml
+include: package:flutter_lints/flutter.yaml
 
 analyzer:
-  strong-mode:
-    implicit-dynamic: true
+  language:
+    strict-inference: true
   errors:
     # treat missing required parameters as a warning (not a hint)
     missing_required_param: warning
@@ -50,7 +50,6 @@ linter:
     - always_declare_return_types
     # - always_put_control_body_on_new_line
     # - always_put_required_named_parameters_first # we prefer having parameters in the same order as fields https://github.com/flutter/flutter/issues/10219
-    - always_require_non_null_named_parameters
     # - always_specify_types
     - annotate_overrides
     # - avoid_annotating_with_dynamic # conflicts with always_specify_types
@@ -109,6 +108,7 @@ linter:
     - library_prefixes
     # - lines_longer_than_80_chars # not yet tested
     - list_remove_unrelated_type
+    - library_private_types_in_public_api
     # - literal_only_boolean_expressions # too many false positives: https://github.com/dart-lang/sdk/issues/34181
     - no_adjacent_strings_in_list
     - no_duplicate_case_values
@@ -134,7 +134,6 @@ linter:
     # - prefer_constructors_over_static_methods # not yet tested
     - prefer_contains
     # - prefer_double_quotes # opposite of prefer_single_quotes
-    - prefer_equal_for_default_values
     # - prefer_expression_function_bodies # conflicts with https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#consider-using--for-short-functions-and-methods
     - prefer_final_fields
     # - prefer_final_in_for_each # not yet tested

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -9,23 +9,23 @@ void main() => runApp(MyApp());
 
 class TestObserver extends NavigatorObserver {
   @override
-  void didPush(Route<dynamic> route, Route<dynamic> previousRoute) {
-    print('didPush $route');
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    debugPrint('didPush $route');
   }
 
   @override
-  void didPop(Route<dynamic> route, Route<dynamic> previousRoute) {
-    print('didPop $route');
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    debugPrint('didPop $route');
   }
 
   @override
-  void didRemove(Route<dynamic> route, Route<dynamic> previousRoute) {
-    print('didRemove $route');
+  void didRemove(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    debugPrint('didRemove $route');
   }
 
   @override
-  void didReplace({Route<dynamic> newRoute, Route<dynamic> oldRoute}) {
-    print('didReplace $oldRoute to $newRoute');
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
+    debugPrint('didReplace $oldRoute to $newRoute');
   }
 }
 

--- a/example/lib/samples/modules/composer/module.dart
+++ b/example/lib/samples/modules/composer/module.dart
@@ -15,9 +15,9 @@ class _ComposerTextRoute extends NuRoute<NuRouter, void, String> {
   Widget build(BuildContext context, NuRouteSettings<void> settings) {
     return TextComposerScreen(
       initialText: settings.rawParameters['initialText'],
-      submitText: (String text) => router.nuvigator.pop(text),
+      submitText: (String text) => router.nuvigator?.pop(text),
       toHelp: () {
-        router.nuvigator.open<void>('composer/help');
+        router.nuvigator?.open<void>('composer/help');
       },
     );
   }
@@ -40,9 +40,9 @@ class _ComposerHelpRoute extends NuRoute {
 
 class ComposerRoute extends NuRoute<NuRouter, void, String> {
   @override
-  Widget build(BuildContext context, NuRouteSettings<Object> settings) {
+  Widget build(BuildContext context, NuRouteSettings<Object?> settings) {
     return Nuvigator.routes(
-      initialRoute: settings.name,
+      initialRoute: settings.name!,
       routes: [
         _ComposerHelpRoute(),
         _ComposerTextRoute(),

--- a/example/lib/samples/modules/composer/screens/help_screen.dart
+++ b/example/lib/samples/modules/composer/screens/help_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 
 class HelpScreen extends StatelessWidget {
+  const HelpScreen({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(

--- a/example/lib/samples/modules/composer/screens/text_composer_screen.dart
+++ b/example/lib/samples/modules/composer/screens/text_composer_screen.dart
@@ -2,18 +2,18 @@ import 'package:flutter/material.dart';
 
 class TextComposerScreen extends StatefulWidget {
   const TextComposerScreen({
-    Key key,
+    super.key,
     this.initialText,
-    @required this.submitText,
-    @required this.toHelp,
-  }) : super(key: key);
+    required this.submitText,
+    required this.toHelp,
+  });
 
-  final String initialText;
+  final String? initialText;
   final Function(String) submitText;
   final VoidCallback toHelp;
 
   @override
-  _TextComposerScreenState createState() => _TextComposerScreenState();
+  State<TextComposerScreen> createState() => _TextComposerScreenState();
 }
 
 class _TextComposerScreenState extends State<TextComposerScreen> {
@@ -21,7 +21,7 @@ class _TextComposerScreenState extends State<TextComposerScreen> {
 
   @override
   void initState() {
-    _controller.text = widget.initialText;
+    _controller.text = widget.initialText ?? '';
     super.initState();
   }
 

--- a/example/lib/samples/modules/friend_request/bloc/friend_request_bloc.dart
+++ b/example/lib/samples/modules/friend_request/bloc/friend_request_bloc.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 class FriendRequestBloc extends ChangeNotifier {
   FriendRequestBloc(this.numberOfRequests)
-      : _accepted = List<bool>(numberOfRequests)
+      : _accepted = List<bool>.filled(numberOfRequests, false, growable: false)
           ..fillRange(0, numberOfRequests, false);
 
   final int numberOfRequests;

--- a/example/lib/samples/modules/friend_request/module.dart
+++ b/example/lib/samples/modules/friend_request/module.dart
@@ -17,7 +17,7 @@ class ListFriendRequestRoute extends NuRoute<NuRouter, void, void> {
   Widget build(BuildContext context, NuRouteSettings<void> settings) {
     final bloc = context.watch<FriendRequestBloc>();
     return ListRequestScreen(
-      toSuccess: () => router.nuvigator.open<void>('friend-requests/success'),
+      toSuccess: () => router.nuvigator?.open<void>('friend-requests/success'),
       numberOfRequests: bloc.numberOfRequests,
     );
   }
@@ -33,8 +33,8 @@ class FriendRequestSuccessRoute extends NuRoute<NuRouter, void, void> {
   @override
   Widget build(BuildContext context, NuRouteSettings<void> settings) {
     return SuccessScreen(
-      closeFlow: () => router.nuvigator.closeFlow(),
-      toComposeText: () => router.nuvigator.open<void>('composer/text'),
+      closeFlow: () => router.nuvigator?.closeFlow(),
+      toComposeText: () => router.nuvigator?.open<void>('composer/text'),
     );
   }
 }

--- a/example/lib/samples/modules/friend_request/screens/list_requests_screen.dart
+++ b/example/lib/samples/modules/friend_request/screens/list_requests_screen.dart
@@ -4,10 +4,10 @@ import 'package:provider/provider.dart';
 
 class ListRequestScreen extends StatelessWidget {
   const ListRequestScreen({
-    Key key,
-    @required this.toSuccess,
-    @required this.numberOfRequests,
-  }) : super(key: key);
+    super.key,
+    required this.toSuccess,
+    required this.numberOfRequests,
+  });
 
   final VoidCallback toSuccess;
   final int numberOfRequests;

--- a/example/lib/samples/modules/friend_request/screens/success_screen.dart
+++ b/example/lib/samples/modules/friend_request/screens/success_screen.dart
@@ -4,10 +4,10 @@ import 'package:provider/provider.dart';
 
 class SuccessScreen extends StatelessWidget {
   const SuccessScreen({
-    Key key,
-    @required this.closeFlow,
-    @required this.toComposeText,
-  }) : super(key: key);
+    super.key,
+    required this.closeFlow,
+    required this.toComposeText,
+  });
 
   final VoidCallback closeFlow;
   final VoidCallback toComposeText;

--- a/example/lib/samples/router.dart
+++ b/example/lib/samples/router.dart
@@ -13,7 +13,7 @@ class FriendRequestArgs {
     this.numberOfRequests,
   });
 
-  final int numberOfRequests;
+  final int? numberOfRequests;
 
   static FriendRequestArgs fromArgs(Map<String, dynamic> args) {
     return FriendRequestArgs(
@@ -40,9 +40,9 @@ class FriendRequestRoute extends NuRoute<NuRouter, FriendRequestArgs, void> {
 
   @override
   Widget build(
-      BuildContext context, NuRouteSettings<FriendRequestArgs> settings) {
+      BuildContext context, NuRouteSettings<FriendRequestArgs?> settings) {
     return ChangeNotifierProvider.value(
-      value: FriendRequestBloc(settings.args.numberOfRequests),
+      value: FriendRequestBloc(settings.args?.numberOfRequests ?? 0),
       child: Nuvigator(
         router: FriendRequestRouter(),
       ),
@@ -58,7 +58,7 @@ class MainAppRouter extends NuRouter {
   @override
   ScreenType get screenType => cupertinoScreenType;
 
-  List<NuRoute> _postInitRoutes;
+  late List<NuRoute> _postInitRoutes;
 
   @override
   Future<void> init(BuildContext context) async {
@@ -94,7 +94,7 @@ class MainAppRouter extends NuRouter {
   HandleDeepLinkFn get onDeepLinkNotFound => (
         INuRouter router,
         Uri uri, [
-        bool isFromNative,
+        bool? isFromNative,
         dynamic args,
       ]) async {
         print('DeepLink not found ${uri.toString()}');

--- a/example/lib/samples/screens/home_screen.dart
+++ b/example/lib/samples/screens/home_screen.dart
@@ -34,7 +34,7 @@ class HomeScreen extends StatelessWidget {
                   onPressed: () {
                     // final r = NuRouter.of<OldFriendRequestRouter>(context);
                     // r.toListRequests();
-                    nuvigator.open<void>(
+                    nuvigator?.open<void>(
                       'exapp://friend-requests?numberOfRequests=10',
                     );
                   },
@@ -42,9 +42,9 @@ class HomeScreen extends StatelessWidget {
                 ),
                 RaisedButton(
                   onPressed: () async {
-                    String text;
+                    String? text;
 
-                    text = await nuvigator.open<String>(
+                    text = await nuvigator?.open<String>(
                       'exapp://composer/text?initialText=Hello+deep+link%21',
                       screenType: cupertinoDialogScreenType,
                     );
@@ -55,7 +55,7 @@ class HomeScreen extends StatelessWidget {
                         context: context,
                         builder: (context) => AlertDialog(
                           title: const Text('Composed message'),
-                          content: Text(text),
+                          content: Text(text ?? ''),
                         ),
                       );
                     }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,10 +1,10 @@
 name: example
 description: A new Flutter project.
 
-version: 1.0.0+1
+version: 1.0.0+2
 
 environment:
-  sdk: ">=2.10.0 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
 
 publish_to: none
 
@@ -18,9 +18,9 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.0.3
+  flutter_lints: ^2.0.0
   flutter_test:
     sdk: flutter
-  pedantic: ^1.11.0
 
 flutter:
   uses-material-design: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: nuvigator
 description: A powerful routing abstraction over Flutter navigator, providing some new features and an easy way to define routers.
-version: 2.0.0-beta.4
+version: 2.0.0-beta.5
 
 homepage: https://github.com/nubank/nuvigator
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <4.0.0'
 
 dependencies:
   analyzer: ^5.2.0
@@ -16,7 +16,7 @@ dependencies:
   recase: ^4.0.0
 
 dev_dependencies:
+  flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter
   mockito: ^5.0.8
-  pedantic: ^1.11.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  analyzer: ^3.2.0
+  analyzer: ^5.2.0
   dart_style: ^2.0.2
   flutter:
     sdk: flutter

--- a/test/nuvigator_test.dart
+++ b/test/nuvigator_test.dart
@@ -1,7 +1,9 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nuvigator/next.dart';
-import 'package:pedantic/pedantic.dart';
+
 
 Widget baseNuvigator(
   Key key,


### PR DESCRIPTION
This PR adds support for Dart 3

- Remove unused dependencies
- Bump flutter SDK to `>=2.17 < 4.0.0`
- Migrate lints to default `flutter_lints`
