### PR TITLE
fix: added function for call pop when nested route

### DIFF
--- a/lib/src/nuvigator.dart
+++ b/lib/src/nuvigator.dart
@@ -404,6 +404,7 @@ class NuvigatorState<T extends INuRouter> extends NavigatorState
       SystemNavigator.pop();
     }
     if (!isPopped && this != rootNuvigator && parent != null) {
+      super.pop<R>();
       parentPop<R>(result);
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,8 @@ environment:
   sdk: '>=2.17.0 <4.0.0'
 
 dependencies:
-  analyzer: ^5.2.0
+  #analyzer: ^5.2.0
+  analyzer: ^4.6.0
   dart_style: ^2.0.2
   flutter:
     sdk: flutter


### PR DESCRIPTION
### **What?**
We need to ensure that the pop method is called for routes that are nested

### **How?**
Forcing the parent method to be called so that pop is invoked