### PR TITLE
Removing observer duplicated

### DIFF
--- a/lib/src/nuvigator.dart
+++ b/lib/src/nuvigator.dart
@@ -416,6 +416,7 @@ class NuvigatorState<T extends INuRouter> extends NavigatorState
       SystemNavigator.pop();
     }
     if (!isPopped && this != rootNuvigator && parent != null) {
+      super.pop<R>(result);
       parentPop<R>(result);
     }
   }

--- a/lib/src/nuvigator.dart
+++ b/lib/src/nuvigator.dart
@@ -189,15 +189,29 @@ class NuvigatorState<T extends INuRouter> extends NavigatorState
     parent = Nuvigator.of(context, nullOk: true);
     if (isNested) {
       parent.nestedNuvigators.add(this);
-      widget.observers
-          .addAll(parent.widget.inheritableObservers.map((f) => f()));
     }
-    widget.observers.addAll(_collectObservers().map((f) => f()));
+    final observers = _removeDuplicateObservers(_collectObservers());
+    if(observers.isNotEmpty) {
+      widget.observers.addAll(observers.map((f) => f()));
+    }
+
     stateTracker = NuvigatorStateTracker();
     widget.observers.add(stateTracker);
     super.initState();
     WidgetsBinding.instance.addObserver(this);
     widget.router.install(this);
+  }
+
+  List<NavigatorObserver Function()> _removeDuplicateObservers(List<NavigatorObserver Function()> observers) {
+    final observerTypes = widget.observers.map((e) => e.runtimeType.toString()).toSet();
+    final definitedObservers = List<NavigatorObserver Function()>.empty(growable: true);
+    for (var observer in observers) {
+      final obsType = observer.runtimeType.toString().replaceAll("() =>", "").trim();
+      if (!observerTypes.contains(obsType)) {
+        definitedObservers.add(observer);
+      }
+    }
+    return definitedObservers;
   }
 
   @override

--- a/lib/src/nuvigator.dart
+++ b/lib/src/nuvigator.dart
@@ -189,7 +189,8 @@ class NuvigatorState<T extends INuRouter> extends NavigatorState
     parent = Nuvigator.of(context, nullOk: true);
     if (isNested) {
       parent.nestedNuvigators.add(this);
-      widget.observers.addAll(parent.widget.inheritableObservers.map((f) => f()));
+      widget.observers
+          .addAll(parent.widget.inheritableObservers.map((f) => f()));
     }
     widget.observers.addAll(_collectObservers().map((f) => f()));
     stateTracker = NuvigatorStateTracker();

--- a/lib/src/nuvigator.dart
+++ b/lib/src/nuvigator.dart
@@ -189,6 +189,7 @@ class NuvigatorState<T extends INuRouter> extends NavigatorState
     parent = Nuvigator.of(context, nullOk: true);
     if (isNested) {
       parent.nestedNuvigators.add(this);
+      widget.observers.addAll(parent.widget.inheritableObservers.map((f) => f()));
     }
     widget.observers.addAll(_collectObservers().map((f) => f()));
     stateTracker = NuvigatorStateTracker();
@@ -416,7 +417,6 @@ class NuvigatorState<T extends INuRouter> extends NavigatorState
       SystemNavigator.pop();
     }
     if (!isPopped && this != rootNuvigator && parent != null) {
-      super.pop<R>(result);
       parentPop<R>(result);
     }
   }

--- a/lib/src/nuvigator.dart
+++ b/lib/src/nuvigator.dart
@@ -191,7 +191,7 @@ class NuvigatorState<T extends INuRouter> extends NavigatorState
       parent.nestedNuvigators.add(this);
     }
     final observers = _removeDuplicateObservers(_collectObservers());
-    if(observers.isNotEmpty) {
+    if (observers.isNotEmpty) {
       widget.observers.addAll(observers.map((f) => f()));
     }
 
@@ -202,11 +202,15 @@ class NuvigatorState<T extends INuRouter> extends NavigatorState
     widget.router.install(this);
   }
 
-  List<NavigatorObserver Function()> _removeDuplicateObservers(List<NavigatorObserver Function()> observers) {
-    final observerTypes = widget.observers.map((e) => e.runtimeType.toString()).toSet();
-    final definitedObservers = List<NavigatorObserver Function()>.empty(growable: true);
+  List<NavigatorObserver Function()> _removeDuplicateObservers(
+      List<NavigatorObserver Function()> observers) {
+    final observerTypes =
+        widget.observers.map((e) => e.runtimeType.toString()).toSet();
+    final definitedObservers =
+        List<NavigatorObserver Function()>.empty(growable: true);
     for (var observer in observers) {
-      final obsType = observer.runtimeType.toString().replaceAll("() =>", "").trim();
+      final obsType =
+          observer.runtimeType.toString().replaceAll('() =>', '').trim();
       if (!observerTypes.contains(obsType)) {
         definitedObservers.add(observer);
       }

--- a/test/observers_test.dart
+++ b/test/observers_test.dart
@@ -53,12 +53,12 @@ class MyApp extends StatelessWidget {
       NuRouteBuilder(
         path: 'home',
         builder: (_, __, ___) =>
-            DummyPage(pageName: 'home', nextRoute: 'second'),
+            const DummyPage(pageName: 'home', nextRoute: 'second'),
       ),
       NuRouteBuilder(
         path: 'second',
         builder: (_, __, ___) =>
-            DummyPage(pageName: 'second', nextRoute: 'nested'),
+            const DummyPage(pageName: 'second', nextRoute: 'nested'),
       ),
       NuRouteBuilder(
         path: 'nested',
@@ -68,12 +68,12 @@ class MyApp extends StatelessWidget {
           routes: [
             NuRouteBuilder(
               path: 'nested_home',
-              builder: (_, __, ___) => DummyPage(
+              builder: (_, __, ___) => const DummyPage(
                   pageName: 'nested_home', nextRoute: 'nested_second'),
             ),
             NuRouteBuilder(
               path: 'nested_second',
-              builder: (_, __, ___) => DummyPage(
+              builder: (_, __, ___) => const DummyPage(
                   pageName: 'nested_second', nextRoute: 'nested_home'),
             ),
           ],

--- a/test/observers_test.dart
+++ b/test/observers_test.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:nuvigator/next.dart';
+
+class MockFakeLog extends Mock implements FakeLog {}
+
+void main() {
+
+  Future<void> _navigateToNextPage(WidgetTester tester, String key) async {
+    await tester.tap(find.byKey(Key(key)));
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> _popCurrentPage(WidgetTester tester, String key) async {
+    await tester.tap(find.byKey(Key(key)));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('pop event must called twice', (WidgetTester tester) async {
+    final mockFakeLog = MockFakeLog();
+    await tester.pumpWidget(MyApp(fakeLog: mockFakeLog));
+    await tester.pumpAndSettle();
+
+    await _navigateToNextPage(tester, 'second');
+    await _navigateToNextPage(tester, 'nested');
+    await _navigateToNextPage(tester, 'nested_second');
+    await _popCurrentPage(tester, 'nested_home-pop');
+
+    verify(mockFakeLog.sayPop()).called(2);
+  });
+}
+
+class MyApp extends StatelessWidget {
+  MyApp({this.fakeLog});
+  final FakeLog fakeLog;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Nuvigator App',
+      builder: Nuvigator.routes(
+        initialRoute: 'home',
+        screenType: materialScreenType,
+        routes: _buildRoutes(),
+        observers: [_createObserver()],
+        inheritableObservers: [_createInheritableObserver()],
+      ),
+    );
+  }
+
+  List<NuRouteBuilder> _buildRoutes() {
+    return [
+      NuRouteBuilder(
+        path: 'home',
+        builder: (_, __, ___) => DummyPage(pageName: 'home', nextRoute: 'second'),
+      ),
+      NuRouteBuilder(
+        path: 'second',
+        builder: (_, __, ___) => DummyPage(pageName: 'second', nextRoute: 'nested'),
+      ),
+      NuRouteBuilder(
+        path: 'nested',
+        builder: (_, __, ___) => Nuvigator.routes(
+          initialRoute: 'nested_home',
+          screenType: materialScreenType,
+          routes: [
+            NuRouteBuilder(
+              path: 'nested_home',
+              builder: (_, __, ___) => DummyPage(pageName: 'nested_home', nextRoute: 'nested_second'),
+            ),
+            NuRouteBuilder(
+              path: 'nested_second',
+              builder: (_, __, ___) => DummyPage(pageName: 'nested_second', nextRoute: 'nested_home'),
+            ),
+          ],
+        ),
+      ),
+    ];
+  }
+
+  DummyObservable _createObserver() => DummyObservable(fakeLog: fakeLog);
+
+  DummyObservable Function() _createInheritableObserver() => () => DummyObservable(fakeLog: fakeLog);
+}
+
+abstract class FakeLog {
+  void sayPop() => print('Hi, I say pop');
+  void sayPush() => print('Hi, I say push');
+  void sayReplace() => print('Hi, I say replace');
+  void sayRemove() => print('Hi, I say remove');
+}
+
+class DummyObservable extends NavigatorObserver {
+
+  DummyObservable({this.fakeLog});
+  FakeLog fakeLog;
+
+  @override
+  void didPop(Route route, Route previousRoute) {
+    fakeLog.sayPop();
+    super.didPop(route, previousRoute);
+  }
+
+  @override
+  void didPush(Route route, Route previousRoute) {
+    fakeLog.sayPush();
+    super.didPush(route, previousRoute);
+  }
+
+  @override
+  void didRemove(Route route, Route previousRoute) {
+    fakeLog.sayRemove();
+    super.didRemove(route, previousRoute);
+  }
+
+  @override
+  void didReplace({Route newRoute, Route oldRoute}) {
+    fakeLog.sayReplace();
+    //super.didReplace(newRoute, oldRoute);
+  }
+}
+
+class DummyPage extends StatelessWidget {
+  DummyPage({this.pageName, this.nextRoute});
+  final String pageName;
+  final String nextRoute;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(pageName)),
+      body: Column(
+        children: [
+          _buildNextButton(context),
+          _buildPopButton(context),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNextButton(BuildContext context) {
+    return Center(
+      child: IconButton(
+        key: Key(nextRoute),
+        icon: const Icon(Icons.navigate_next),
+        onPressed: () => Nuvigator.of(context).open(nextRoute),
+      ),
+    );
+  }
+
+  Widget _buildPopButton(BuildContext context) {
+    return Center(
+      child: ElevatedButton(
+        key: Key('$nextRoute-pop'),
+        onPressed: () => Nuvigator.of(context).pop(),
+        child: const Text('pop'),
+      ),
+    );
+  }
+}

--- a/test/observers_test.dart
+++ b/test/observers_test.dart
@@ -28,6 +28,16 @@ void main() {
 
     verify(mockFakeLog.sayPop()).called(2);
   });
+
+  testWidgets('push event must be called 4 times', (WidgetTester tester) async {
+    final mockFakeLog = MockFakeLog();
+    await tester.pumpWidget(MyApp(fakeLog: mockFakeLog));
+    await tester.pumpAndSettle();
+
+    await _navigateToNextPage(tester, 'second');
+
+    verify(mockFakeLog.sayPush()).called(4);
+  });
 }
 
 class MyApp extends StatelessWidget {

--- a/test/observers_test.dart
+++ b/test/observers_test.dart
@@ -26,7 +26,7 @@ void main() {
     await _navigateToNextPage(tester, 'nested_second');
     await _popCurrentPage(tester, 'nested_home-pop');
 
-    verify(mockFakeLog.sayPop()).called(2);
+    verify(mockFakeLog.sayPop()).called(1);
   });
 
   testWidgets('push event must be called 4 times', (WidgetTester tester) async {
@@ -36,7 +36,7 @@ void main() {
 
     await _navigateToNextPage(tester, 'second');
 
-    verify(mockFakeLog.sayPush()).called(4);
+    verify(mockFakeLog.sayPush()).called(2);
   });
 }
 

--- a/test/observers_test.dart
+++ b/test/observers_test.dart
@@ -6,7 +6,6 @@ import 'package:nuvigator/next.dart';
 class MockFakeLog extends Mock implements FakeLog {}
 
 void main() {
-
   Future<void> _navigateToNextPage(WidgetTester tester, String key) async {
     await tester.tap(find.byKey(Key(key)));
     await tester.pumpAndSettle();
@@ -53,11 +52,13 @@ class MyApp extends StatelessWidget {
     return [
       NuRouteBuilder(
         path: 'home',
-        builder: (_, __, ___) => DummyPage(pageName: 'home', nextRoute: 'second'),
+        builder: (_, __, ___) =>
+            DummyPage(pageName: 'home', nextRoute: 'second'),
       ),
       NuRouteBuilder(
         path: 'second',
-        builder: (_, __, ___) => DummyPage(pageName: 'second', nextRoute: 'nested'),
+        builder: (_, __, ___) =>
+            DummyPage(pageName: 'second', nextRoute: 'nested'),
       ),
       NuRouteBuilder(
         path: 'nested',
@@ -67,11 +68,13 @@ class MyApp extends StatelessWidget {
           routes: [
             NuRouteBuilder(
               path: 'nested_home',
-              builder: (_, __, ___) => DummyPage(pageName: 'nested_home', nextRoute: 'nested_second'),
+              builder: (_, __, ___) => DummyPage(
+                  pageName: 'nested_home', nextRoute: 'nested_second'),
             ),
             NuRouteBuilder(
               path: 'nested_second',
-              builder: (_, __, ___) => DummyPage(pageName: 'nested_second', nextRoute: 'nested_home'),
+              builder: (_, __, ___) => DummyPage(
+                  pageName: 'nested_second', nextRoute: 'nested_home'),
             ),
           ],
         ),
@@ -81,7 +84,8 @@ class MyApp extends StatelessWidget {
 
   DummyObservable _createObserver() => DummyObservable(fakeLog: fakeLog);
 
-  DummyObservable Function() _createInheritableObserver() => () => DummyObservable(fakeLog: fakeLog);
+  DummyObservable Function() _createInheritableObserver() =>
+      () => DummyObservable(fakeLog: fakeLog);
 }
 
 abstract class FakeLog {
@@ -92,7 +96,6 @@ abstract class FakeLog {
 }
 
 class DummyObservable extends NavigatorObserver {
-
   DummyObservable({this.fakeLog});
   FakeLog fakeLog;
 

--- a/test/observers_test.dart
+++ b/test/observers_test.dart
@@ -31,7 +31,7 @@ void main() {
 }
 
 class MyApp extends StatelessWidget {
-  MyApp({this.fakeLog});
+  const MyApp({this.fakeLog});
   final FakeLog fakeLog;
 
   @override
@@ -125,7 +125,7 @@ class DummyObservable extends NavigatorObserver {
 }
 
 class DummyPage extends StatelessWidget {
-  DummyPage({this.pageName, this.nextRoute});
+  const DummyPage({this.pageName, this.nextRoute});
   final String pageName;
   final String nextRoute;
 

--- a/test/observers_test.dart
+++ b/test/observers_test.dart
@@ -128,9 +128,9 @@ class DummyObservable extends NavigatorObserver {
   }
 
   @override
-  void didReplace({Route newRoute, Route oldRoute}) {
+  void didReplace({Route<dynamic> newRoute, Route oldRoute}) {
     fakeLog.sayReplace();
-    //super.didReplace(newRoute, oldRoute);
+    super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
   }
 }
 


### PR DESCRIPTION
### **What?**
It was identified that for root navigation, when there is an observer that must be inherited, and it has already been registered in the observer property, it is registered twice.
We need to ensure that there is only one observer record per navigation.

### **How?**
A function has been implemented that only allows you to register an observer if it does not exist.

_This function has O(n) complexity and guarantees efficiency regardless of the number of observers._