### PR TITLE
Remove deprecated hash function to support Flutter 3.27

### DIFF
--- a/lib/src/nu_route_settings.dart
+++ b/lib/src/nu_route_settings.dart
@@ -34,7 +34,7 @@ class NuRouteSettings<A extends Object?> extends RouteSettings {
       '${objectRuntimeType(this, 'NuRouteSettings')}("$name", "$pathTemplate", $rawParameters, $arguments)';
 
   @override
-  int get hashCode => hashList([name, rawParameters, pathTemplate]);
+  int get hashCode => Object.hashAll([name, rawParameters, pathTemplate]);
 
   @override
   bool operator ==(Object other) {


### PR DESCRIPTION
In order to use the library on newer Flutter releases, we must migrate from the removed 'hashList' to the 'Object.hashAll' introduced in Dart 2.14.

This is safe to in all releases, as the current min SDK is Dart 2.17