### PR TITLE
Bump flutter 3.32.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout
+      - run: flutter pub get
       - run: dart format -o none --set-exit-if-changed .
   analyze:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 job_defaults: &defaults
     docker:
-      - image: ghcr.io/cirruslabs/flutter:3.10.5
+      - image: ghcr.io/cirruslabs/flutter:3.32.0
 
 jobs:
   format-check:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -35,7 +35,6 @@ analyzer:
     # Ignore analyzer hints for updating pubspecs when using Future or
     # Stream and not importing dart:async
     # Please see https://github.com/flutter/flutter/pull/24528 for details.
-    sdk_version_async_exported_from_core: ignore
     # Review lints ignore after migrating all to package next
     constant_identifier_names: ignore
     use_build_context_synchronously: ignore
@@ -108,12 +107,10 @@ linter:
     - hash_and_equals
     - implementation_imports
     # - invariant_booleans # too many false positives: https://github.com/dart-lang/linter/issues/811
-    - iterable_contains_unrelated_type
     # - join_return_with_assignment # not yet tested
     - library_names
     - library_prefixes
     # - lines_longer_than_80_chars # not yet tested
-    - list_remove_unrelated_type
     # - library_private_types_in_public_api
     # - literal_only_boolean_expressions # too many false positives: https://github.com/dart-lang/sdk/issues/34181
     - no_adjacent_strings_in_list
@@ -124,7 +121,6 @@ linter:
     # - one_member_abstracts # too many false positives
     # - only_throw_errors # https://github.com/flutter/flutter/issues/5792
     - overridden_fields
-    - package_api_docs
     - package_names
     - package_prefixed_library_names
     # - parameter_assignments # we do this commonly

--- a/example/lib/samples/modules/friend_request/screens/list_requests_screen.dart
+++ b/example/lib/samples/modules/friend_request/screens/list_requests_screen.dart
@@ -15,7 +15,7 @@ class ListRequestScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final bloc = Provider.of<FriendRequestBloc>(context);
-    final bodyStyle = Theme.of(context).textTheme.bodyText1;
+    final bodyStyle = Theme.of(context).textTheme.bodyLarge;
 
     return Scaffold(
       appBar: AppBar(

--- a/example/lib/samples/modules/friend_request/screens/success_screen.dart
+++ b/example/lib/samples/modules/friend_request/screens/success_screen.dart
@@ -15,7 +15,7 @@ class SuccessScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final bloc = Provider.of<FriendRequestBloc>(context);
-    final headingStle = Theme.of(context).textTheme.headline4;
+    final headingStle = Theme.of(context).textTheme.headlineMedium;
 
     return Scaffold(
       appBar: AppBar(

--- a/example/lib/samples/screens/home_screen.dart
+++ b/example/lib/samples/screens/home_screen.dart
@@ -8,7 +8,7 @@ class HomeScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     debugPrint('BUILDING HOME');
     final nuvigator = Nuvigator.of(context);
-    final headingStle = Theme.of(context).textTheme.headline3;
+    final headingStle = Theme.of(context).textTheme.displaySmall;
 
     return Scaffold(
       appBar: AppBar(

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.0.3
-  flutter_lints: ^2.0.0
+  flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter
 

--- a/test/nuvigator_test.dart
+++ b/test/nuvigator_test.dart
@@ -106,14 +106,11 @@ Future<NuvigatorStateTracker> pumpApp(
   // ignore: omit_local_variable_types
   final GlobalKey<NuvigatorState<INuRouter>> secondNestedNuvigatorKey =
       GlobalKey(debugLabel: 'NUVIGATOR_TESTER');
-  await tester.pumpWidget(TickerMode(
-    enabled: false,
-    child: baseNuvigator(
-      nuvigatorKey,
-      nestedNuvigatorKey,
-      secondNestedNuvigatorKey,
-      shouldRebuild: shouldRebuild,
-    ),
+  await tester.pumpWidget(baseNuvigator(
+    nuvigatorKey,
+    nestedNuvigatorKey,
+    secondNestedNuvigatorKey,
+    shouldRebuild: shouldRebuild,
   ));
   await tester.pumpAndSettle();
   return NuvigatorStateTracker(
@@ -549,7 +546,7 @@ void main() {
   });
 
   testWidgets(
-    'Should Nuvigator when shouldRebuild is provided',
+    'Should rebuild secondNested Nuvigator when shouldRebuild is provided',
     (tester) async {
       final tracker = await pumpApp(
         tester,
@@ -588,7 +585,7 @@ void main() {
       tracker.rootNuvigator!.pop();
       await tester.pumpAndSettle();
 
-      // Should rebuild NuRouter (going back to secondNestedScreen1)
+      // Should rebuild secondNested Nuvigator (going back to secondNestedScreen1)
       expect(find.text('SecondNestedScreen1'), findsOneWidget);
 
       expect(
@@ -603,7 +600,7 @@ void main() {
 
       expect(
         tracker.secondNestedStack.map((e) => e!.settings.name),
-        ['secondNestedScreen1', 'secondNestedScreen2'],
+        ['secondNestedScreen1'],
       );
     },
   );


### PR DESCRIPTION
Bump CICD to use flutter 3.32.0.

Fix the `example` app and some tests which started to break after Flutter 3.19.0 due to a regression fix.